### PR TITLE
Remove EmitSownOnEntityOnlyToPlayerAfterDelay and fix sh_onboarding.gnut

### DIFF
--- a/vscripts/_utility.gnut
+++ b/vscripts/_utility.gnut
@@ -2550,12 +2550,6 @@ void function EmitSoundOnEntityToTeamExceptPlayer( entity ent, string sound, int
 	}
 }
 
-void function EmitSoundOnEntityOnlyToPlayerAfterDelay( entity ent, entity player, string sound, float delay )
-{
-	wait delay
-	EmitSoundOnEntityOnlyToPlayer( ent, player, sound )
-}
-
 #if R5DEV
 // DEV function to toggle player view between the skybox and the real world.
 void function ToggleSkyboxView( float scale = 0.001 )

--- a/vscripts/sh_onboarding.gnut
+++ b/vscripts/sh_onboarding.gnut
@@ -219,6 +219,8 @@ void function Sequence_PickLoadout()
 					ItemFlavor_GetGUID( selectedCharacter ) // Currently selected loadout character
 				] )
 		}
+
+		wait CharSelect_GetPickingDelayAfterEachLock()
 	}
 
 	// Reset selection step to lock all character selection loadout slots
@@ -230,17 +232,17 @@ void function Sequence_PickLoadout()
 
 	wait CharSelect_GetPickingDelayAfterAll()
 
-	wait CharSelect_GetOutroTransitionDuration()
+	wait CharSelect_GetOutroTransitionDuration() + CharSelect_GetOutroSceneChangeDuration() / 3.5 - CharSelect_GetPickingDelayAfterEachLock() * MAX_TEAM_PLAYERS
 
 	if ( CharSelect_PlayerSquadIntroEnabled() ) {
 		if ( CharSelect_PostSelectionMusicEnabled() )
 			foreach ( player in GetPlayerArray() )
 			{
 				string skydiveMusicID = MusicPack_GetSkydiveMusic( LoadoutSlot_GetItemFlavor( ToEHI( player ), Loadout_MusicPack() ) )
-				thread EmitSoundOnEntityOnlyToPlayerAfterDelay( player, player, skydiveMusicID, 1.3 )
+				EmitSoundOnEntityOnlyToPlayer( player, player, skydiveMusicID )
 			}
 
-		wait CharSelect_GetOutroSquadPresentDuration()
+		wait CharSelect_GetOutroSquadPresentDuration() - CharSelect_GetOutroSceneChangeDuration() / 3.5
 	}
 
 	thread Sequence_Prematch()
@@ -386,6 +388,8 @@ void function DecideRespawnPlayer( entity player, bool giveLoadoutWeapons = true
 
 	DoRespawnPlayer( player, null )
 
+	Remote_CallFunction_NonReplay( player, "ServerCallback_YouRespawned" )
+
 	PlayerStopSpectating( player )
 
 	ItemFlavor playerCharacterSkin = LoadoutSlot_GetItemFlavor( ToEHI( player ), Loadout_CharacterSkin( playerCharacter ) )
@@ -400,6 +404,8 @@ void function DecideRespawnPlayer( entity player, bool giveLoadoutWeapons = true
 
 	player.SetPlayerNetBool( "pingEnabled", true )
 	player.SetHealth( 100 )
+
+	UpdatePlayerCounts()
 }
 #endif
 
@@ -484,8 +490,10 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 
 	UpdatePlayerCounts()
 
-	if ( attacker.IsPlayer() && victim.IsPlayer() )
+	if ( attacker.IsPlayer() && victim.IsPlayer() && attacker != victim )
 		attacker.SetPlayerNetInt( "kills", attacker.GetPlayerNetInt( "kills" ) + 1 )
+
+	Remote_CallFunction_NonReplay( victim, "ServerCallback_YouDied", attacker, GetHealthFrac( victim ), DamageInfo_GetDamageSourceIdentifier( damageInfo ), DamageInfo_GetDamage( damageInfo ) )
 }
 
 void function OnClientConnected( entity player )


### PR DESCRIPTION
EmitSownOnEntityOnlyToPlayerAfterDelay was removed because it is not present in the normal r5r.

Fixed delay in background music when moving from legend selection to squad introduction.

Fixed a problem where CharSelect_GetPickingDelayAfterEachLock was not being used.

ServerCallback_YouDied when a player dies and ServerCallback_YouRespawned when a player respawns.

This will cause player_death_begin_survival to be played when the player dies, and the number of surviving players will be corrected when the player respawns.

The kill count is no longer increased when a player commits suicide.