### PR TITLE
Revert the changes in sh_onboarding.gnut

### DIFF
--- a/vscripts/sh_onboarding.gnut
+++ b/vscripts/sh_onboarding.gnut
@@ -195,7 +195,7 @@ void function Sequence_PickLoadout()
 	{
 		float startTime = Time()
 
-		float timeSpentOnSelection = Survival_GetCharacterSelectDuration( pickIndex )
+		float timeSpentOnSelection = Survival_GetCharacterSelectDuration( pickIndex ) + CharSelect_GetPickingDelayAfterEachLock()
 		if ( pickIndex == 0 )
 			timeSpentOnSelection += CharSelect_GetPickingDelayOnFirst()
 
@@ -232,8 +232,8 @@ void function Sequence_PickLoadout()
 
 	wait CharSelect_GetPickingDelayAfterAll()
 
-	wait CharSelect_GetOutroSquadPresentDuration() - CharSelect_GetOutroSceneChangeDuration() / 3.5
-	
+	wait CharSelect_GetOutroTransitionDuration() + CharSelect_GetOutroSceneChangeDuration() / 3.5 - CharSelect_GetPickingDelayAfterEachLock() * MAX_TEAM_PLAYERS
+
 	if ( CharSelect_PlayerSquadIntroEnabled() ) {
 		if ( CharSelect_PostSelectionMusicEnabled() )
 			foreach ( player in GetPlayerArray() )
@@ -242,7 +242,7 @@ void function Sequence_PickLoadout()
 				EmitSoundOnEntityOnlyToPlayer( player, player, skydiveMusicID )
 			}
 
-		wait CharSelect_GetOutroSquadPresentDuration()
+		wait CharSelect_GetOutroSquadPresentDuration() - CharSelect_GetOutroSceneChangeDuration() / 3.5
 	}
 
 	thread Sequence_Prematch()


### PR DESCRIPTION
The changes made to the legend selection part of sh_onboarding.gnut make it behave a little strange and need to be reverted.
With the current script, the music when transitioning to the squad introduction is delayed and the transition to the dropship scene is too fast.
I will post a video of how it is buggy:

https://user-images.githubusercontent.com/90076182/190892326-4cb7b23c-eb5f-4e2a-a833-e58a265b6388.mp4

