### PR TITLE
Precache thunderdome cage ceiling

### DIFF
--- a/vscripts/gamemodes/custom_aimtrainer/_aimtrainer.nut
+++ b/vscripts/gamemodes/custom_aimtrainer/_aimtrainer.nut
@@ -95,6 +95,7 @@ void function _ChallengesByColombia_Init()
 	PrecacheModel($"mdl/imc_interior/imc_int_fusebox_01.rmdl")
 	PrecacheModel($"mdl/barriers/shooting_range_target_02.rmdl")
 	PrecacheModel($"mdl/thunderdome/thunderdome_cage_wall_256x256_01.rmdl")
+	PrecacheModel($"mdl/thunderdome/thunderdome_cage_ceiling_256x256_06.rmdl")
 	PrecacheModel( $"mdl/pipes/slum_pipe_large_yellow_256_02.rmdl" )
 	
 	//death callback for player because some challenges can kill player


### PR DESCRIPTION
Currently crashes with below error:
```
[2022-09-20 00:40:15.597] [40.128] Script(U):UICodeCallback_ErrorDialog: There was a problem processing game logic.
Please try again.

------
_utility.gnut #1538
[SERVER] Failed to load (or didn't precache) mdl/thunderdome/thunderdome_cage_ceiling_256x256_06.rmdl
```