### PR TITLE
Rename "R5DEV" --> "DEVELOPER" see description ( !! required for next SDK release !! )

### DIFF
--- a/vscripts/_anim.gnut
+++ b/vscripts/_anim.gnut
@@ -371,7 +371,7 @@ function __PlayAnim( guy, animation_name, reference = null, optionalTag = null, 
 
 	guy.SetNextThinkNow()
 
-	#if !R5DEV
+	#if !DEVELOPER
 	if ( guy.IsNPC() && !guy.IsInterruptable() )
 	{
 		// better than nothing failsafe

--- a/vscripts/_clientcommands.gnut
+++ b/vscripts/_clientcommands.gnut
@@ -15,7 +15,7 @@ void function ClientCommands_Init()
 
 	AddClientCommandCallback( "recharge", ClientCommand_recharge )
 
-	#if R5DEV
+	#if DEVELOPER
 	//AddClientCommandCallback( "script", ClientCommand_script )
 	#endif
 }
@@ -111,7 +111,7 @@ bool function ClientCommand_recharge( entity player, array<string> args )
 	return true
 }
 
-#if R5DEV
+#if DEVELOPER
 bool function ClientCommand_script( entity player, array<string> args )
 {
 	if( !IsValid( player ) )

--- a/vscripts/_codecallbacks_common.gnut
+++ b/vscripts/_codecallbacks_common.gnut
@@ -408,12 +408,12 @@ void function RunClassPostDamageCallbacks( entity ent, var damageInfo )
 
 	foreach ( callbackFunc in file.classPostDamageCallbacks[className] )
 	{
-		#if R5DEV
+		#if DEVELOPER
 		float damage = DamageInfo_GetDamage( damageInfo )
 		#endif
 		callbackFunc( ent, damageInfo )
 
-		#if R5DEV
+		#if DEVELOPER
 		Assert( damage == DamageInfo_GetDamage( damageInfo ), "Damage changed in a post damage callback" )
 		#endif
 	}
@@ -452,7 +452,7 @@ void function RemoveDeathCallback( string className, void functionref( entity, v
 
 void function AddSoulDeathCallback( void functionref( entity, var ) callbackFunc )
 {
-	#if R5DEV
+	#if DEVELOPER
 	foreach ( func in svGlobal.soulDeathFuncs )
 	{
 		Assert( func != callbackFunc , "Already added " + string( callbackFunc ) + " with AddSoulDeathCallback" )
@@ -714,7 +714,7 @@ void function RemoveEntityCallback_OnPostDamaged( entity ent, void functionref( 
 
 void function AddEntityCallback_OnKilled( entity ent, void functionref( entity, var ) callbackFunc )
 {
-	#if R5DEV
+	#if DEVELOPER
 	foreach ( func in  ent.e.entKilledCallbacks )
 	{
 		Assert( func != callbackFunc , "Already added " + string( callbackFunc ) + " to entity" )
@@ -738,7 +738,7 @@ void function RemoveEntityCallback_OnKilled( entity ent, void functionref( entit
 
 void function AddEntityCallback_OnPostShieldDamage( entity ent, void functionref( entity, var, float ) callbackFunc )
 {
-	#if R5DEV
+	#if DEVELOPER
 	foreach ( func in  ent.e.entPostShieldDamageCallbacks )
 	{
 		Assert( func != callbackFunc , "Already added " + string( callbackFunc ) + " to entity" )

--- a/vscripts/_init.gnut
+++ b/vscripts/_init.gnut
@@ -1,4 +1,4 @@
-#if R5DEV
+#if DEVELOPER
 untyped
 #endif
 

--- a/vscripts/_pain_death_sounds.gnut
+++ b/vscripts/_pain_death_sounds.gnut
@@ -186,7 +186,7 @@ void function PainDeathSounds_Init()
 		painOrDeathSound.blocksPriority = blocksPriority
 		painOrDeathSound.priority = priority
 
-		#if R5DEV
+		#if DEVELOPER
 		if ( priority < 100 || priority > 500 )
 			Warning( "PainDeathSound event priority must be between 100 and 500. See " + event + " " + method )
 		#endif
@@ -465,7 +465,7 @@ void function PlayPainOrDeathSounds( array<PainOrDeathSound> soundEvents, entity
 		}
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 	if ( !file.painDeathDebug )
 		return
 

--- a/vscripts/_script_movers.gnut
+++ b/vscripts/_script_movers.gnut
@@ -141,7 +141,7 @@ void function CodeCallback_PreBuildAINFile()
 
 void function ScriptedDoorInit( entity door )
 {
-	#if R5DEV
+	#if DEVELOPER
 	array validModels = [ // TODO: Fix
 		$"models/door/door_imc_interior_03_128_animated.mdl",
 		$"models/door/pod_door_Hangar_IMC_01_animated.mdl",
@@ -272,7 +272,7 @@ void function CreateDoorMoverModel( asset door, pos, angle, physics)
 
 void function ScriptedSwitchInit( entity button )
 {
-	#if R5DEV
+	#if DEVELOPER
 	array< asset > validModels = [
 		$"models/domestic/light_switch_touchscreen.mdl",
 		$"models/props/pressure_plates/pressure_plate_titan_industrial_01.mdl",

--- a/vscripts/_scripttest.gnut
+++ b/vscripts/_scripttest.gnut
@@ -1,7 +1,7 @@
 
 global function ScriptCompilerTest
 
-#if R5DEV
+#if DEVELOPER
 // This script is for testing the script compiler.
 
 global typedef GlobalTypedefTest int
@@ -685,11 +685,11 @@ void function TestTypes()
 	Assert( "" == $"" )
 }
 
-#endif // DEV
+#endif // DEVELOPER
 
 void function ScriptCompilerTest()
 {
-	#if R5DEV
+	#if DEVELOPER
 		ScriptCompilerTestDev()
 		if ( Dev_CommandLineHasParm( "-scriptdocs" ) )
 			DumpConstTable( expect table( getroottable().originalConstTable ) )
@@ -701,7 +701,7 @@ void function ScriptCompilerTest()
 
 
 
-#if R5DEV
+#if DEVELOPER
 
 
 struct ConstTableEntry

--- a/vscripts/_sh_init.gnut
+++ b/vscripts/_sh_init.gnut
@@ -90,7 +90,7 @@ void function SV_CL_Init()
 	if(GameRules_GetGameMode() == "map_editor")
 		ShAssets_Init()
 
-	#if R5DEV
+	#if DEVELOPER
 		ShDevUtility_Init()
 		CaptureMode_Shared_Init()
 	#endif
@@ -315,9 +315,9 @@ void function Server_Init()
 	PilotsPassage_Init()
 	SneakPeek_Init()
 	JumpPad_Init()
-	#if R5DEV
+	#if DEVELOPER
 		SmokeTest_Init()
-	#endif // DEV
+	#endif // DEVELOPER
 }
 #endif // SERVER
 

--- a/vscripts/_threads.nut
+++ b/vscripts/_threads.nut
@@ -29,7 +29,7 @@ global function LevelVarInit
 global bool reloadingScripts = false
 global bool reloadedScripts = false
 
-#if R5DEV
+#if DEVELOPER
 global function __serialize_state
 global function __evalBreakpoint
 #endif
@@ -146,7 +146,7 @@ void function LevelVarInit()
 }
 
 
-#if R5DEV
+#if DEVELOPER
 
 //********************************************************************************************
 // _vscript_code.nut
@@ -340,4 +340,4 @@ void function __serialize_state()
 	}
 }
 
-#endif // DEV
+#endif // DEVELOPER

--- a/vscripts/_utility.gnut
+++ b/vscripts/_utility.gnut
@@ -64,7 +64,7 @@ void function Utility_Init()
 	RegisterSignal( "InventoryChanged" )
 
 	//AddClientCommandCallback( "OnDevnetBugScreenshot", ClientCommand_OnDevnetBugScreenshot )
-	#if R5DEV
+	#if DEVELOPER
 		FlagInit( "AimAssistSwitchTest_Enabled" )
 		// AddClientCommandCallback( "DoomTitan", ClientCommand_DoomTitan )
 		AddClientCommandCallback( "toggleconsole", ClientCommand_ToggleConsole )
@@ -101,7 +101,7 @@ void function GiveAllTitans()
 	}
 }
 
-#if R5DEV
+#if DEVELOPER
 void function KillAllBadguys()
 {
 	array<entity> npcs = GetNPCArrayOfEnemies( GetPlayerArray()[0].GetTeam() )
@@ -2550,7 +2550,7 @@ void function EmitSoundOnEntityToTeamExceptPlayer( entity ent, string sound, int
 	}
 }
 
-#if R5DEV
+#if DEVELOPER
 // DEV function to toggle player view between the skybox and the real world.
 void function ToggleSkyboxView( float scale = 0.001 )
 {
@@ -2631,7 +2631,7 @@ void function DamageRange( float value, float headShotMultiplier, int playerHeal
 	printt( format( "%i             %i              %i", numHeadshots, 0, numHeadshots ) )
 }
 
-#endif // DEV
+#endif // DEVELOPER
 
 void function MuteAll( entity player, int fadeOutTime = 2 )
 {
@@ -2876,7 +2876,7 @@ void function __SetSignalDelayedThread( entity ent, string signal, float delay )
 		Signal( ent, signal )
 }
 
-#if R5DEV
+#if DEVELOPER
 table function GetPlayerPos( entity player = null )
 {
 	if ( !player )
@@ -2942,7 +2942,7 @@ void function ToggleHud()
 			AddCinematicFlag( player, flag )
 	}
 }
-#endif // DEV
+#endif // DEVELOPER
 
 void function ClearChildren( entity parentEnt, bool b0 ) //Probably should have code give us a GetChildren() function that returns a list instead of having to iterate through NextMovePeer
 {
@@ -2988,7 +2988,7 @@ void function UpdateBadRepPresent()
 
 void function Dev_PrintMessage( entity player, string text, string subText = "", float duration = 7.0, string soundAlias = "" )
 {
-	#if R5DEV
+	#if DEVELOPER
 	// Build the message on the client
 	string sendMessage
 	for ( int textType = 0 ; textType < 2 ; textType++ )
@@ -3317,7 +3317,7 @@ void function ShowCrit( entity ent )
 }
 
 
-#if R5DEV
+#if DEVELOPER
 void function TeleportEnemyBotToView()
 {
 	entity player = gp()[0]
@@ -4209,7 +4209,7 @@ int function GameScore_GetWinningTeam_ThisRound()
 	return TEAM_UNASSIGNED
 }
 
-#if R5DEV
+#if DEVELOPER
 void function KillIMC()
 {
 	array<entity> enemies = GetNPCArrayOfTeam( TEAM_IMC )
@@ -4313,7 +4313,7 @@ bool function IsFastPilot( entity player )
 
 void function KillPlayer( entity player, int damageSource )
 {
-	#if R5DEV
+	#if DEVELOPER
 	printt( "Played Killed from script: " )
 	DumpStack()
 	#endif

--- a/vscripts/_utility_shared.nut
+++ b/vscripts/_utility_shared.nut
@@ -148,7 +148,7 @@ void function InitWeaponScripts()
 	MpWeaponLifelineBatonPrimary_Init()
 	MpWeaponDeployableCover_Init()
 
-	#if R5DEV
+	#if DEVELOPER
 		MeleeShadowsquadHands_Init()
 		MpWeaponShadowsquadHandsPrimary_Init()
 		MDLSpawner_Init()
@@ -4482,7 +4482,7 @@ vector function OffsetPointRelativeToVector( vector point, vector offset, vector
 #if SERVER
 float function GetRoundTimeLimit_ForGameMode()
 {
-#if R5DEV
+#if DEVELOPER
 	if ( level.devForcedTimeLimit )
 	{
 		//Make it needed to be called multiple times for RoundBasedGameModes

--- a/vscripts/ai/_ai_drone.gnut
+++ b/vscripts/ai/_ai_drone.gnut
@@ -127,7 +127,7 @@ function EngineerDroneHasNoOwner( drone )
 function RunDroneTypeThink( drone )
 {
 	expect entity( drone )
-	#if R5DEV
+	#if DEVELOPER
 	Assert( !( "RunDroneTypeThink" in drone.s ), "Already ran drone think!" )
 	drone.s.RunDroneTypeThink <- true
 	#endif

--- a/vscripts/ai/_ai_spawn.gnut
+++ b/vscripts/ai/_ai_spawn.gnut
@@ -80,7 +80,7 @@ void function AiSpawn_Init()
 	// RegisterSignal( "OnFinishedAssaultChain" )
 
 	// AiSpawnContent_Init()
-	// #if R5DEV
+	// #if DEVELOPER
 	// // just to insure that ai settings are being setup properly.
 	// InitNpcSettingsFileNamesForDevMenu()
 	// SetupSpawnAIButtons( TEAM_MILITIA )
@@ -90,7 +90,7 @@ void function AiSpawn_Init()
 
 void function AiSpawn_EntitiesDidLoad()
 {
-	#if R5DEV
+	#if DEVELOPER
 	//	On load in dev, verify that subclass matches leveled_aisettings. Subclass is being eradicated.
 	foreach ( spawner in GetSpawnerArrayByClassName( "npc_titan" ) )
 	{
@@ -596,7 +596,7 @@ void function StopAssaultMoveTarget( entity npc )
 
 void function InitInfoMoveTargetFlags( entity infoMoveTarget )
 {
-	#if R5DEV
+	#if DEVELOPER
 	if ( infoMoveTarget.HasKey( "script_goal_radius" ) )
 	{
 		int radius = int( infoMoveTarget.kv.script_goal_radius )

--- a/vscripts/ai/_ai_spawn_content.gnut
+++ b/vscripts/ai/_ai_spawn_content.gnut
@@ -20,7 +20,7 @@ function AiSpawnContent_Init()
 	if ( IsMultiplayer() )
 		file.pilotAntiTitanWeapons = [ "mp_weapon_rocket_launcher" ]
 
-	// #if R5DEV
+	// #if DEVELOPER
 	// if ( IsSingleplayer() )
 	// {
 	// 	array<string> aiSettings = GetAllowedTitanAISettings()
@@ -411,7 +411,7 @@ function CommonNPCOnSpawned( entity npc )
 	thread AssaultLinkedMoveTarget( npc )
 
 	FixupTitle( npc )
-	#if R5DEV
+	#if DEVELOPER
 	// stop all the wandering in sp_enemies.
 	if ( GetMapName() == "sp_enemies" )
 		npc.DisableNPCFlag( NPC_ALLOW_PATROL | NPC_ALLOW_INVESTIGATE )

--- a/vscripts/ai/_ai_utility.gnut
+++ b/vscripts/ai/_ai_utility.gnut
@@ -8,7 +8,7 @@ struct{
 
 void function RecordingAnimationTest()
 {
-	entity player = gp()[0]
+	entity player = GetPlayerArray()[0]
 	vector initialpos = player.GetOrigin()
 	vector initialang = player.GetAngles()
 	player.StartRecordingAnimation(initialpos, initialang)
@@ -38,7 +38,7 @@ void function CreateGravitationalForce( )
 	point_push.kv.enabled = 1
 	point_push.kv.magnitude = 50
 	point_push.kv.radius = 150
-	point_push.SetOrigin( gp()[0].GetOrigin() )//+ gp()[0].GetForwardVector()*250 )
+	point_push.SetOrigin( GetPlayerArray()[0].GetOrigin() )//+ GetPlayerArray()[0].GetForwardVector()*250 )
 	DispatchSpawn( point_push )
 	point_push.Fire( "Enable" )
 	// point_push.Fire( "Kill", "", 0.2 )

--- a/vscripts/cl_mapspawn.gnut
+++ b/vscripts/cl_mapspawn.gnut
@@ -121,7 +121,7 @@ void function ClientCodeCallback_MapSpawn()
 
 	PrecacheResFiles()
 
-	#if R5DEV
+	#if DEVELOPER
 		ClModelViewInit()
 	#endif
 

--- a/vscripts/cl_survival_inventory.nut
+++ b/vscripts/cl_survival_inventory.nut
@@ -439,7 +439,7 @@ void function UICallback_BackpackOpened()
 
 void function UICallback_BackpackClosed()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( !IsValidSignal( "BackpackClosed" ) ) //
 			return
 	#endif

--- a/vscripts/cl_survival_loot.nut
+++ b/vscripts/cl_survival_loot.nut
@@ -1510,7 +1510,7 @@ entity function GetEntityPlayerIsLookingAt( entity player, array<entity> ents, f
 		lootItem.playerViewDot = dot
 		finalLootEnts.append( lootItem )
 
-#if R5DEV
+#if DEVELOPER
 		//DebugDrawMark( ent.GetWorldSpaceCenter(), 10, [255, 128, 0], true, 10.0 )
 		//DebugDrawText( ent.GetWorldSpaceCenter() + <0,0,16>, format( "%f\n", dot ), false, 0.1 )
 #endif

--- a/vscripts/class/CBaseEntity.nut
+++ b/vscripts/class/CBaseEntity.nut
@@ -7,7 +7,7 @@ global function CodeCallback_RegisterClass_CBaseEntity
 // Properties and methods added here can be accessed on all script entities
 //=========================================================
 
-#if R5DEV
+#if DEVELOPER
 table __scriptVarDelegate = {}
 #endif
 
@@ -36,7 +36,7 @@ function CodeCallback_RegisterClass_CBaseEntity()
 
 	function CBaseEntity::constructor()
 	{
-		#if R5DEV
+		#if DEVELOPER
 			this.s = delegate __scriptVarDelegate : {}
 		#else
 			this.s = {}
@@ -47,7 +47,7 @@ function CodeCallback_RegisterClass_CBaseEntity()
 		this.funcsByString = {}
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		function __scriptVarDelegate::_typeof()
 		{
 			return "ScriptVariableTable"

--- a/vscripts/client/_cl_model_viewer.nut
+++ b/vscripts/client/_cl_model_viewer.nut
@@ -1,4 +1,4 @@
-#if R5DEV
+#if DEVELOPER
 untyped
 #endif
 
@@ -6,7 +6,7 @@ global function ServerCallback_MVUpdateModelBounds
 global function ServerCallback_MVEnable
 global function ServerCallback_MVDisable
 
-#if R5DEV
+#if DEVELOPER
 global function ClModelViewInit
 global function ModelViewerSpawnModel
 global function SelectNextModel
@@ -236,11 +236,11 @@ void function RefreshHudLabels()
 		file.hudDPad.SetText( "Move X/Y" )
 	}
 }
-#endif // DEV
+#endif // DEVELOPER
 
 void function ServerCallback_MVUpdateModelBounds( int index, float minX, float minY, float minZ, float maxX, float maxY, float maxZ )
 {
-	#if R5DEV
+	#if DEVELOPER
 		table<string, vector> tab = { mins = <minX,minY,minZ>, maxs = <maxX,maxY,maxZ> }
 
 		if ( index < file.modelBounds.len() )
@@ -256,12 +256,12 @@ void function ServerCallback_MVUpdateModelBounds( int index, float minX, float m
 
 			file.modelBounds.append( tab )
 		}
-	#endif // DEV
+	#endif // DEVELOPER
 }
 
 void function ServerCallback_MVEnable()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( !SetModelViewerMode( MODELVIEWERMODE_GAMEPAD ) )
 			return
 
@@ -310,12 +310,12 @@ void function ServerCallback_MVEnable()
 		GetLocalClientPlayer().ClientCommand( "mp_enabletimelimit 0" )
 
 		ModelViewerModeEnabled()
-	#endif // DEV
+	#endif // DEVELOPER
 }
 
 void function ServerCallback_MVDisable()
 {
-	#if R5DEV
+	#if DEVELOPER
 		file.modelViewerMode = MODELVIEWERMODE_INACTIVE
 
 		UpdateMainHudVisibility( GetLocalViewPlayer() )
@@ -356,10 +356,10 @@ void function ServerCallback_MVDisable()
 
 		GetLocalClientPlayer().ClientCommand( "mp_enablematchending " + file.lastEnablematchending )
 		GetLocalClientPlayer().ClientCommand( "mp_enabletimelimit " + file.lastEnabletimelimit )
-	#endif // DEV
+	#endif // DEVELOPER
 }
 
-#if R5DEV
+#if DEVELOPER
 void function ReloadShared()
 {
 	file.modelViewerModels = GetModelViewerList()
@@ -1619,4 +1619,4 @@ void function ClientCodeCallback_LevelEd_ClearPreviewEntity()
 	file.hlmv_modelData = {}
 	file.hlmv_lastModel = $""
 }
-#endif // DEV
+#endif // DEVELOPER

--- a/vscripts/client/cl_damage_indicator.gnut
+++ b/vscripts/client/cl_damage_indicator.gnut
@@ -590,7 +590,7 @@ void function SCB_AddGrenadeIndicatorForEntity( int team, int ownerHandle, int e
 	if ( !level.grenadeIndicatorEnabled )
 		return
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( !level.clientScriptInitialized )
 			return
 	#endif
@@ -610,7 +610,7 @@ void function SCB_AddGrenadeIndicatorForEntity( int team, int ownerHandle, int e
 
 void function TryAddGrenadeIndicator( entity grenade )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( !level.clientScriptInitialized )
 			return
 	#endif

--- a/vscripts/client/cl_death_screen.gnut
+++ b/vscripts/client/cl_death_screen.gnut
@@ -1842,6 +1842,12 @@ asset function GetGladCardReplacementImageForDamageSourceID( int damageSourceID 
 	return $""
 }
 
+void function SignalUpdate()
+{
+	wait 0.1
+	file.deathRecapDataUpdated = true
+	Signal( GetLocalClientPlayer(), "DeathRecapDataUpdated" )
+}
 
 void function ServerCallback_SendDeathRecapData( int attackerEHandle, int victimEHandle, int damageSourceID, int damageType, int totalDamage, int hitCount, int headShotBits, float healthFrac, float shieldFrac, float blockTime )
 {
@@ -1956,13 +1962,6 @@ void function DEV_TestDeathScreenMenu()
 	//
 
 	thread SignalUpdate()
-}
-
-void function SignalUpdate()
-{
-	wait 0.1
-	file.deathRecapDataUpdated = true
-	Signal( GetLocalClientPlayer(), "DeathRecapDataUpdated" )
 }
 
 array<DeathRecapDamageData> function CreateFakeRecapData( entity victim, array<entity> enemyArray )

--- a/vscripts/client/cl_death_screen.gnut
+++ b/vscripts/client/cl_death_screen.gnut
@@ -35,7 +35,7 @@ global function IsViewingDeathRecap
 global function IsViewingDeathScreen
 global function DeathScreenSummaryShouldFadeIn
 
-#if R5DEV
+#if DEVELOPER
 global function GetRecapPlayerEHIArray
 global function DEV_TestDeathScreenMenu
 global function GetKeyFromEnum
@@ -1835,7 +1835,7 @@ asset function GetGladCardReplacementImageForDamageSourceID( int damageSourceID 
 
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		Warning( "GetGladCardReplacementImageForDamageSourceID doesn't handle damageSourceID: " + damageSourceID )
 	#endif
 
@@ -1927,7 +1927,7 @@ EncodedEHandle function GetKillerEnum()
 }
 
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_TestDeathScreenMenu()
 {
 	array<entity> playerArray = GetPlayerArray_Alive()

--- a/vscripts/client/cl_dof.gnut
+++ b/vscripts/client/cl_dof.gnut
@@ -330,7 +330,7 @@ bool function GetPlayerTrace( entity enemy, vector playerViewOrigin, vector enem
 
 	expect TraceResults( trace )
 
-	#if R5DEV
+	#if DEVELOPER
 	if ( file.debugMode )
 	{
 		DebugDrawLine( playerViewOrigin, trace.endPos, 0, 255, 0, false, 0.1 )
@@ -396,7 +396,7 @@ void function GetDesiredFarDistFromEnemies( AdsVars vars, AdsInternalVars adsInt
 		if ( !npcTraceFunc( enemy, playerViewOrigin, enemyOrigin ) )
 			continue
 
-		#if R5DEV
+		#if DEVELOPER
 		if ( file.debugMode )
 		{
 			vector offset = <3,3,3>

--- a/vscripts/client/cl_main_hud.nut
+++ b/vscripts/client/cl_main_hud.nut
@@ -695,7 +695,7 @@ void function ClientHudInit( entity player )
 {
 	Assert( player == GetLocalClientPlayer() )
 
-	#if R5DEV
+	#if DEVELOPER
 		HudElement( "Dev_Info1" ).Hide()
 		HudElement( "Dev_Info2" ).Hide()
 		HudElement( "Dev_Info3" ).Hide()
@@ -723,7 +723,7 @@ void function ClientHudInit( entity player )
 				}*/
 			}
 		}
-	#endif // DEV
+	#endif // DEVELOPER
 }
 
 
@@ -891,7 +891,7 @@ bool function ShouldMainHudBeVisible( entity player )
 			return false
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( IsModelViewerActive() )
 			return false
 	#endif
@@ -956,7 +956,7 @@ bool function ShouldPermanentHudBeVisible( entity player )
 	if ( (!player.IsObserver() || player.GetObserverTarget() == player || player.GetObserverTarget() == null) && !IsAlive( player ) )
 		return false
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( IsModelViewerActive() )
 			return false
 	#endif

--- a/vscripts/client/cl_minimap.gnut
+++ b/vscripts/client/cl_minimap.gnut
@@ -40,7 +40,7 @@ global function GetMinimapBackgroundTileImage
 global function SetMapFeatureItem
 global function RemoveMapFeatureItemByName
 
-#if R5DEV
+#if DEVELOPER
 global function DumpMinimapHandles
 #endif
 
@@ -66,7 +66,7 @@ struct {
 
 	var minimap_indicator
 
-	#if R5DEV
+	#if DEVELOPER
 		table<int, entity> minimapHandles
 	#endif
 
@@ -353,7 +353,7 @@ var function CreateMinimapRui( asset ruiAsset, int sortKey = 0 )
 	return rui
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DumpMinimapHandles()
 {
 	int index = 0
@@ -363,7 +363,7 @@ void function DumpMinimapHandles()
 		++index
 	}
 }
-#endif // DEV
+#endif // DEVELOPER
 
 void function ClientCodeCallback_MinimapEntitySpawned( entity ent )
 {
@@ -444,7 +444,7 @@ void function AddMinimapObject( entity ent )
 		return
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		int eHandle = ent.GetEncodedEHandle()
 
 		{

--- a/vscripts/client/cl_player.gnut
+++ b/vscripts/client/cl_player.gnut
@@ -49,7 +49,7 @@ global function ClientPlayerClassChanged
 global function GetHideCrosshairHitIndicatorOverride
 global function SetHideCrosshairHitIndicatorOverride
 
-#if R5DEV
+#if DEVELOPER
 global function BloodSprayDecals_Toggle
 #endif
 
@@ -260,7 +260,7 @@ function Pressed_RequestTitanfall( entity player )
 	if ( !IsTitanAvailable( player ) )
 		return
 
-	#if R5DEV
+	#if DEVELOPER
 		printt( player.GetEntIndex(), "Requested replacement Titan from eye pos " + player.EyePosition() + " view angles " + player.EyeAngles() + " player origin " + player.GetOrigin() + " map " + GetMapName() )
 	#endif
 
@@ -1022,7 +1022,7 @@ BloodDecalParams function BloodDecal_GetParams( float damageAmount, bool isHeadS
 	return params
 }
 
-#if R5DEV
+#if DEVELOPER
 string function BloodSprayDecals_Toggle()
 {
 	string returnStr = ""

--- a/vscripts/client/cl_squad_display.gnut
+++ b/vscripts/client/cl_squad_display.gnut
@@ -670,7 +670,7 @@ void function _PopulatePlayerStatsRui( var cardElem, int index, bool connected )
 	{
 		//
 		Hud_Hide( cardElem )
-		#if R5DEV
+		#if DEVELOPER
 			printt( "ClearPlayerStatsRui", index )
 		#endif
 		ClearPlayerStatsRui( Hud_GetRui( cardElem ) )

--- a/vscripts/client/cl_utility.gnut
+++ b/vscripts/client/cl_utility.gnut
@@ -165,7 +165,7 @@ void function AddCreateCallback( string className, void functionref( entity ) ca
 	if ( !( className in clGlobal.onCreateCallbacks ) )
 		clGlobal.onCreateCallbacks[ className ] <- []
 
-#if R5DEV
+#if DEVELOPER
 	foreach ( func in clGlobal.onCreateCallbacks[ className ] )
 	{
 		Assert( func != callbackFunc )
@@ -180,7 +180,7 @@ void function AddTargetNameCreateCallback( string targetName, void functionref( 
 	if ( !( targetName in clGlobal.onTargetNameCreateCallbacks ) )
 		clGlobal.onTargetNameCreateCallbacks[ targetName ] <- []
 
-#if R5DEV
+#if DEVELOPER
 	foreach ( func in clGlobal.onTargetNameCreateCallbacks[ targetName ] )
 	{
 		Assert( func != callbackFunc )
@@ -687,7 +687,7 @@ float function GetNextRespawnTime( entity player )
 	return expect float( player.nv.nextRespawnTime - 0.0 ) // - 0.0 to force this to be a float
 }
 
-#if R5DEV
+#if DEVELOPER
 void function TwoPinTest()
 {
 	entity player = gp()[0]
@@ -1088,7 +1088,7 @@ bool function ShouldShowWeakpoints( entity ent )
 			return false
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( Dev_CommandLineHasParm( "-noweakpoints" ) )
 			return false
 	#endif
@@ -1314,7 +1314,7 @@ void function AddCallback_OnStaticPropRUICreated( void functionref( StaticPropRu
 	clGlobal.onStaticPropRUICreatedCallbacks.append( callbackFunc )
 }
 
-#if R5DEV
+#if DEVELOPER
 table<int, StaticPropRui> DEV_magicIdStaticPropRuiMap
 bool DEV_staticPropRuiVisibilityDebugEnabled = false
 void function DEV_ToggleStaticPropRuiVisibilityDebug()
@@ -1344,7 +1344,7 @@ void function ClientCodeCallback_OnEnumStaticPropRui( StaticPropRui propRui )
 			callbackFunc( propRui, rui )
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		DEV_magicIdStaticPropRuiMap[propRui.magicId] <- propRui
 	#endif
 }
@@ -1356,7 +1356,7 @@ void function ClientCodeCallback_OnStaticPropRuiVisibilityChange( array<int> new
 
 	ClApexScreens_OnStaticPropRuiVisibilityChange( newlyVisible, newlyHidden )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_staticPropRuiVisibilityDebugEnabled )
 		{
 			if ( newlyVisible.len() > 0 )
@@ -1380,7 +1380,7 @@ void function ClientCodeCallback_OnStaticPropRuiVisibilityChange( array<int> new
 	#endif
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DumpFullscreenRuis()
 {
 	printt( "DumpFullscreenRuis" )

--- a/vscripts/client/rui/cl_hud.gnut
+++ b/vscripts/client/rui/cl_hud.gnut
@@ -470,7 +470,7 @@ bool function ShouldShowProjectileHitDot( int damageType, entity weapon )
 	if ( !IsValid( weapon ) )
 		return false
 
-	#if R5DEV
+	#if DEVELOPER
 		// disables hit dots for video capture
 		if ( GetCurrentPlaylistVarBool( "hud_projectile_hit_dots_disabled", false ) )
 			return false

--- a/vscripts/client/rui/cl_weapon_status.gnut
+++ b/vscripts/client/rui/cl_weapon_status.gnut
@@ -20,7 +20,7 @@ global function NotifyReloadAttemptButNoReserveAmmo
 
 global function UpdateWeaponStatusOnBindingChange
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_TestUltimateStates
 global function GetUltimateWeaponState
 #endif //DEV
@@ -48,7 +48,7 @@ struct
 	array<void functionref( entity, var, int )> weaponStatusUpdateCallbacks
 	array<void functionref( entity, var )>      primaryWeaponStatusUpdateCallbacks
 
-	#if R5DEV
+	#if DEVELOPER
 		bool devTestingUltimateStates
 	#endif //DEV
 } file
@@ -997,7 +997,7 @@ void function UltimateWeaponStatusUpdate( entity player, var rui, int slot )
 	// and one callback when the weapon becomes ready to fire. Though that seems to happen at odd moments.
 	// It's unfortunate that it's so hard to get the state that an weapon is in. :-(
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.devTestingUltimateStates )
 			return
 	#endif //DEV
@@ -1080,7 +1080,7 @@ void function UltimateReadyVideoFinished( int channel )
 	Signal( clGlobal.levelEnt, "ultimate_video_finished" )
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_TestUltimateStates()
 {
 	thread DEV_TestUltimateStatesThread()

--- a/vscripts/conversation/_survival_commentary.gnut
+++ b/vscripts/conversation/_survival_commentary.gnut
@@ -210,7 +210,7 @@ void function OnPlayerKilled( entity victim, entity attacker, var damageInfo )
 
 void function AddSurvivalCommentaryEvent ( int event, entity player = null, entity victim = null )
 {
-	#if R5DEV
+	#if DEVELOPER
 	string enumString = GetEnumString( "eSurvivalEventType", event )
 	
 	printt( FUNC_NAME(), "eSurvivalEventType:", enumString, event )
@@ -394,7 +394,7 @@ string function SurvivalCommentary_GetAlternativeSound( string sound, int max, i
 
 void function SurvivalCommentary_PlaySoundForAllPlayers( string sound )
 {
-	#if R5DEV
+	#if DEVELOPER
 	printt( FUNC_NAME(), "playing sound:", sound, "to all players" )
 	#endif
 
@@ -408,7 +408,7 @@ void function SurvivalCommentary_PlaySoundForAllPlayers( string sound )
 void function SurvivalCommentary_PlaySoundForAllPlayersAfterDelay( string sound, float delay )
 {
 	wait delay
-	#if R5DEV
+	#if DEVELOPER
 	printt( FUNC_NAME(), "playing sound:", sound, "to all players" )
 	#endif
 

--- a/vscripts/conversation/cl_survival_commentary.gnut
+++ b/vscripts/conversation/cl_survival_commentary.gnut
@@ -20,9 +20,9 @@ global function SurvivalCommentary_ClearCurrentSpeakerPrefix
 global function SurvivalCommentary_IsEnabled
 global function GetBattleChatterAlias1P3P
 
-#if R5DEV
+#if DEVELOPER
 global function GetBattleChatterAlias1P3PWithTempVoice
-#endif //R5DEV
+#endif // DEVELOPER
 
 global function ServerCallback_Survival_PlayCrowdEvent
 global function ServerCallback_Survival_NewKillLeader
@@ -581,7 +581,7 @@ string function GetBattleChatterAlias1P3P( entity player, string aliasSubname, b
 	return result
 }
 
-#if R5DEV
+#if DEVELOPER
 string function GetBattleChatterAlias1P3PWithTempVoice( string aliasSubname, bool firstPerson )
 {
 	string voice = TEMP_VOICE

--- a/vscripts/gamemodes/_frontline.gnut
+++ b/vscripts/gamemodes/_frontline.gnut
@@ -46,7 +46,7 @@ Frontline function GetFrontline( int team )
 void function AddCalculateFrontlineCallback( void functionref( int ) callbackFunc )
 {
 	// Check if this function has already been added
-	#if R5DEV
+	#if DEVELOPER
 		foreach ( func in file.calculateFrontlineCallbacks )
 		{
 			Assert( func != callbackFunc )
@@ -58,7 +58,7 @@ void function AddCalculateFrontlineCallback( void functionref( int ) callbackFun
 
 void function CalculateFrontline( int team )
 {
-	#if R5DEV
+	#if DEVELOPER
 		float debugTime = 0.2
 	#endif
 
@@ -81,7 +81,7 @@ void function CalculateFrontline( int team )
 		file.frontline.combatDir = Normalize( militiaCenter - imcCenter ) // combatDir is for TEAM_IMC by default
 		file.frontline.line = CrossProduct( file.frontline.combatDir, <0,0,1> )
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( DEBUG_FRONTLINE )
 			{
 				DrawBox( militiaCenter, <-8,-8,-8>, <8,8,8>, 255, 102, 0, true, debugTime )
@@ -91,7 +91,7 @@ void function CalculateFrontline( int team )
 		#endif
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEBUG_FRONTLINE )
 		{
 			DrawBox( file.frontline.origin, <-32,-32,-32>, <32,32,32>, 255, 0, 0, true, debugTime )

--- a/vscripts/gamemodes/cl_gamemode_survival.nut
+++ b/vscripts/gamemodes/cl_gamemode_survival.nut
@@ -95,7 +95,7 @@ global function SetNextCircleDisplayCustomClear
 
 global function SetChampionScreenRuiAsset
 global function InitSurvivalHealthBar
-#if R5DEV
+#if DEVELOPER
 global function Dev_ShowVictorySequence
 global function Dev_AdjustVictorySequence
 #endif
@@ -630,7 +630,7 @@ void function Cl_Survival_AddClient( entity player )
 	getroottable().testRui <- file.dpadMenuRui
 	SetDpadMenuVisible()
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( GetBugReproNum() == 1972 )
 			file.pilotRui = CreatePermanentCockpitPostFXRui( $"ui/survival_player_hud_editor_version.rpak", HUD_Z_BASE )
 		else
@@ -1787,7 +1787,7 @@ void function ShowMapRui()
 
 bool function MapDevCheatsAreActive()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( !GetConVarBool( "sv_cheats" ) )
 			return false
 		if ( InputIsButtonDown( KEY_LSHIFT ) || InputIsButtonDown( BUTTON_STICK_LEFT ) )
@@ -2759,7 +2759,7 @@ vector function ConvertNormalizedPosToWorldPos( vector normalizedPos, float zoom
 //
 bool function Survival_HandleKeyInput( int key )
 {
-#if R5DEV
+#if DEVELOPER
 	if ( MapDevCheatsAreActive() )
 	{
 		switch ( key )
@@ -3775,7 +3775,7 @@ SquadSummaryData function GetSquadSummaryData()
 	return file.squadSummaryData
 }
 
-#if R5DEV
+#if DEVELOPER
 void function Dev_ShowVictorySequence()
 {
 	ServerCallback_AddWinningSquadData( -1, -1, 0, 0, 0, 0, 0 )
@@ -3823,7 +3823,7 @@ void function SetSquadDataToLocalTeam()
 
 	int maxTrackedSquadMembers = PersistenceGetArrayCount( "lastGameSquadStats" )
 
-	#if R5DEV
+	#if DEVELOPER
 		printt( "PD: Reading Match Summary Persistet Vars for", player, "and", maxTrackedSquadMembers, "maxTrackedSquadMembers" )
 	#endif
 
@@ -3832,7 +3832,7 @@ void function SetSquadDataToLocalTeam()
 	{
 		int eHandle = player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].eHandle" )
 
-		#if R5DEV
+		#if DEVELOPER
 			printt( "PD: ", i, "eHandle", player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].eHandle" ) )
 		#endif
 
@@ -3848,7 +3848,7 @@ void function SetSquadDataToLocalTeam()
 		data.revivesGiven = player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].revivesGiven" )
 		data.respawnsGiven = player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].respawnsGiven" )
 
-		#if R5DEV
+		#if DEVELOPER
 			printt( "PD: ", i, "kills", player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].kills" ) )
 			printt( "PD: ", i, "damageDealt", player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].damageDealt" ) )
 			printt( "PD: ", i, "survivalTime", player.GetPersistentVarAsInt( "lastGameSquadStats[" + i + "].survivalTime" ) )
@@ -3861,7 +3861,7 @@ void function SetSquadDataToLocalTeam()
 
 	file.squadSummaryData.squadPlacement = player.GetPersistentVarAsInt( "lastGameRank" )
 
-	#if R5DEV
+	#if DEVELOPER
 		printt( "PD: squadPlacement", player.GetPersistentVarAsInt( "lastGameRank" ) )
 	#endif
 
@@ -4002,7 +4002,7 @@ void function ShowVictorySequence( bool placementMode = false )
 			CharacterSkin_Apply( characterModel, characterSkin )
 			cleanupEnts.append( characterModel )
 
-			#if R5DEV
+			#if DEVELOPER
 				if ( GetBugReproNum() == 1111 )
 				{
 					var topo = CreateRUITopology_Worldspace( OffsetPointRelativeToVector( pos, < 0, -50, 0 >, characterModel.GetForwardVector() ), characterAngles + <0, 180, 0>, 1000, 500 )
@@ -4033,7 +4033,7 @@ void function ShowVictorySequence( bool placementMode = false )
 			#endif
 
 
-			#if R5DEV
+			#if DEVELOPER
 				if ( GetBugReproNum() == 1111 || GetBugReproNum() == 2222 )
 				{
 					playersOnPodium++
@@ -4116,7 +4116,7 @@ void function ShowVictorySequence( bool placementMode = false )
 
 		wait camera_move_duration - 0.5
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( placementMode )
 			{
 				if ( IsValid( platformModel ) )
@@ -4166,7 +4166,7 @@ void function ShowVictorySequence( bool placementMode = false )
 
 	file.IsShowingVictorySequence = false
 
-	#if R5DEV
+	#if DEVELOPER
 		printt( "PD: IsSquadDataPersistenceEmpty", IsSquadDataPersistenceEmpty() )
 	#endif
 

--- a/vscripts/init.nut
+++ b/vscripts/init.nut
@@ -7,8 +7,6 @@
 global function printl
 global function CodeCallback_Precompile
 
-global const bool R5DEV = true
-
 global struct EchoTestStruct
 {
 	int test1
@@ -592,7 +590,7 @@ void function printl( var text )
 
 void function CodeCallback_Precompile()
 {
-#if R5DEV
+#if DEVELOPER
 	// save the const table for later printing when documenting code consts
 	//if ( Dev_CommandLineHasParm( "-scriptdocs" ) )
 		getroottable().originalConstTable <- clone getconsttable()

--- a/vscripts/lobby/lobbyvm/_lobbyvm.nut
+++ b/vscripts/lobby/lobbyvm/_lobbyvm.nut
@@ -30,7 +30,7 @@ bool function ClientCommand_ResfreshServers(entity player, array<string> args)
     if( !IsValid( player ) )
         return false
 
-    if( gp()[0] != player)
+    if( GetPlayerArray()[0] != player)
         return false
 
     foreach( p in GetPlayerArray() ) {
@@ -45,7 +45,7 @@ bool function ClientCommand_JoinServer(entity player, array<string> args)
     if( !IsValid( player ) )
         return false
 
-    if( gp()[0] != player)
+    if( GetPlayerArray()[0] != player)
         return false
 
     if(args.len() < 1)
@@ -67,7 +67,7 @@ bool function ClientCommand_StartMatch(entity player, array<string> args)
     if( !IsValid( player ) )
         return false
 
-    if( gp()[0] != player)
+    if( GetPlayerArray()[0] != player)
         return false
 
     foreach( p in GetPlayerArray() ) {
@@ -86,7 +86,7 @@ bool function ClientCommand_KickPlayer(entity player, array<string> args)
     if( !IsValid( player ) )
         return false
 
-    if( gp()[0] != player)
+    if( GetPlayerArray()[0] != player)
         return false
 
     if(args.len() < 1)
@@ -111,7 +111,7 @@ bool function ClientCommand_BanPlayer(entity player, array<string> args)
     if( !IsValid( player ) )
         return false
 
-    if( gp()[0] != player)
+    if( GetPlayerArray()[0] != player)
         return false
 
     if(args.len() < 1)
@@ -148,7 +148,7 @@ bool function ClientCommand_ChangedServerSetting(entity player, array<string> ar
     if( !IsValid( player ) )
         return false
 
-    if( gp()[0] != player)
+    if( GetPlayerArray()[0] != player)
         return false
 
     if(args.len() < 2)

--- a/vscripts/lobby/lobbyvm/cl_lobbyvm.nut
+++ b/vscripts/lobby/lobbyvm/cl_lobbyvm.nut
@@ -35,37 +35,37 @@ void function OnResolutionChanged_UpdateClientUI()
 
 void function UICallback_SetHostName(string name)
 {
-    if(GetLocalClientPlayer() == gp()[0])
+    if(GetLocalClientPlayer() == GetPlayerArray()[0])
         GetLocalClientPlayer().ClientCommand("hostname " + name)
 }
 
 void function UICallback_RefreshServer()
 {
-    if(GetLocalClientPlayer() == gp()[0])
+    if(GetLocalClientPlayer() == GetPlayerArray()[0])
         GetLocalClientPlayer().ClientCommand("lobby_refreshservers")
 }
 
 void function UICallback_StartMatch()
 {
-    if(GetLocalClientPlayer() == gp()[0])
+    if(GetLocalClientPlayer() == GetPlayerArray()[0])
         GetLocalClientPlayer().ClientCommand("lobby_startmatch")
 }
 
 void function UICallback_CheckForHost()
 {
-    if(GetLocalClientPlayer() == gp()[0])
+    if(GetLocalClientPlayer() == GetPlayerArray()[0])
         RunUIScript( "EnableCreateMatchUI" )
 }
 
 void function UICodeCallback_UpdateServerInfo(int type, string text)
 {
-    if(GetLocalClientPlayer() == gp()[0])
+    if(GetLocalClientPlayer() == GetPlayerArray()[0])
         GetLocalClientPlayer().ClientCommand("lobby_updateserversetting " + type + " " + text)
 }
 
 void function UICodeCallback_KickOrBanPlayer(int type, string player)
 {
-    if(GetLocalClientPlayer() != gp()[0])
+    if(GetLocalClientPlayer() != GetPlayerArray()[0])
         return
     
     switch (type)
@@ -81,7 +81,7 @@ void function UICodeCallback_KickOrBanPlayer(int type, string player)
 
 void function UICallback_ServerBrowserJoinServer(int id)
 {
-    if(GetLocalClientPlayer() == gp()[0])
+    if(GetLocalClientPlayer() == GetPlayerArray()[0])
         GetLocalClientPlayer().ClientCommand("lobby_joinserver " + id)
 }
 
@@ -119,7 +119,7 @@ void function ServerCallback_LobbyVM_UpdateUI()
 
         string playername = player.GetPlayerName()
 
-        if(gp()[0] == player)
+        if(GetPlayerArray()[0] == player)
         {
             playername = "[Host] " + player.GetPlayerName()
         }
@@ -127,13 +127,13 @@ void function ServerCallback_LobbyVM_UpdateUI()
         RunUIScript( "AddPlayerToUIArray", playername )
     }
 
-    RunUIScript( "UpdateHostName", gp()[0].GetPlayerName() )
+    RunUIScript( "UpdateHostName", GetPlayerArray()[0].GetPlayerName() )
 
     RunUIScript( "UpdatePlayersList" )
 
-    RunUIScript( "ServerBrowser_EnableRefreshButton", gp()[0] == GetLocalClientPlayer() )
+    RunUIScript( "ServerBrowser_EnableRefreshButton", GetPlayerArray()[0] == GetLocalClientPlayer() )
 
-    RunUIScript( "InPlayersLobby" , gp()[0] != GetLocalClientPlayer() && GetPlayerArray().len() > 1, gp()[0].GetPlayerName())
+    RunUIScript( "InPlayersLobby" , GetPlayerArray()[0] != GetLocalClientPlayer() && GetPlayerArray().len() > 1, GetPlayerArray()[0].GetPlayerName())
 }
 
 void function ServerCallback_LobbyVM_SelectionUpdated(int type)

--- a/vscripts/melee/sh_melee.gnut
+++ b/vscripts/melee/sh_melee.gnut
@@ -126,7 +126,7 @@ void function OnItemFlavorRegistered_Character( ItemFlavor characterClass )
 	entry.networkTo = eLoadoutNetworking.PLAYER_EXCLUSIVE
 	fileLevel.characterMeleeSkinLoadoutEntryMap[characterClass] <- entry
 
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		AddCallback_ItemFlavorLoadoutSlotDidChange_AnyPlayer( entry, void function( EHI playerEHI, ItemFlavor meleeSkin ) {
 			DEV_UpdatePlayerMeleeWeaponCosmetics( FromEHI( playerEHI ), meleeSkin )
 		} )
@@ -657,7 +657,7 @@ bool function ClientCodeCallback_ShowMeleePrompt( entity player )
 //// Dev functions ////
 ///////////////////////
 ///////////////////////
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function DEV_UpdatePlayerMeleeWeaponCosmetics( entity player, ItemFlavor unused )
 {
 	// TEMP COMMENT

--- a/vscripts/mp/_base_gametype.gnut
+++ b/vscripts/mp/_base_gametype.gnut
@@ -1534,7 +1534,7 @@ int function CodeCallback_GetWeaponDamageSourceId( entity weapon )
 {
 	string classname = weapon.GetWeaponClassName()
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( ("devWeapons" in level) && classname in level.devWeapons )
 			return 0
 

--- a/vscripts/mp/_changemap.nut
+++ b/vscripts/mp/_changemap.nut
@@ -8,8 +8,8 @@ void function CodeCallback_MatchIsOver()
 	else
 		SetUIVar( level, "putPlayerInMatchmakingAfterDelay", false )
 
-#if R5DEV
+#if DEVELOPER
 	if ( !IsMatchmakingServer() )
 		GameRules_ChangeMap( "mp_lobby", GAMETYPE )
-#endif // #if R5DEV
+#endif // #if DEVELOPER
 }

--- a/vscripts/mp/_model_viewer.nut
+++ b/vscripts/mp/_model_viewer.nut
@@ -7,7 +7,7 @@ global function ToggleModelViewer
 
 global modelViewerModels = []
 
-#if R5DEV
+#if DEVELOPER
 struct
 {
 	bool initialized
@@ -19,11 +19,11 @@ struct
 	bool dpadDownPressed = true
 	var lastTitanAvailability
 } file
-#endif // DEV
+#endif // DEVELOPER
 
 function ModelViewer_Init()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( reloadingScripts )
 			return
 		AddClientCommandCallback( "ModelViewer", ClientCommand_ModelViewer )
@@ -32,7 +32,7 @@ function ModelViewer_Init()
 
 function ToggleModelViewer()
 {
-	#if R5DEV
+	#if DEVELOPER
 		entity player = GetPlayerArray()[ 0 ]
 		if ( !file.active )
 		{
@@ -74,7 +74,7 @@ function ToggleModelViewer()
 	#endif
 }
 
-#if R5DEV
+#if DEVELOPER
 function ModelViewerDisableConflicts()
 {
 	disable_npcs() //Just disable_npcs() for now, will probably add things later
@@ -177,4 +177,4 @@ function WeaponsRestore()
 	}
 }
 
-#endif // DEV
+#endif // DEVELOPER

--- a/vscripts/mp/_titan_npc.nut
+++ b/vscripts/mp/_titan_npc.nut
@@ -465,7 +465,7 @@ function NPCTitanFollowPilotInit( npcTitan, player )
 //////////////////////////////////////////////////////////
 function NPCTitanGuardModeInit( npcTitan )
 {
-#if R5DEV // Bug 110047
+#if DEVELOPER // Bug 110047
 	Assert( IsValid( npcTitan ) )
 	if ( !npcTitan.IsTitan() && !npcTitan.IsNPC() )
 		printl( "npcTitan is " + npcTitan.GetClassName() )

--- a/vscripts/mp/_titan_transfer.nut
+++ b/vscripts/mp/_titan_transfer.nut
@@ -613,7 +613,7 @@ function PilotBecomesTitan( entity player, entity titan, bool fullCopy = true )
 	// 	callbackFunc( player, titan )
 	// }
 
-	// #if R5DEV
+	// #if DEVELOPER
 	// 	thread Dev_CheckTitanIsDeletedAtEndOfPilotBecomesTitan( titan )
 	// #endif
 }

--- a/vscripts/mp/levels/cl_mp_rr_canyonlands_64k_x_64k.nut
+++ b/vscripts/mp/levels/cl_mp_rr_canyonlands_64k_x_64k.nut
@@ -73,7 +73,7 @@ void function OnLeviathanMarkerCreated( entity marker )
 {
 	string markerTargetName = marker.GetTargetName()
 	printt( "OnLeviathanMarkerCreated, targetName: " + markerTargetName  )
-	#if R5DEV
+	#if DEVELOPER
 		if ( IsValid( file.clientSideLeviathan1 ) && markerTargetName == CANYONLANDS_LEVIATHAN1_NAME )
 		{
 			printt( "Destroying clientSideLeviathan1 with markerName: " + markerTargetName  )

--- a/vscripts/mp/levels/mp_rr_canyonlands_common.nut
+++ b/vscripts/mp/levels/mp_rr_canyonlands_common.nut
@@ -2,7 +2,7 @@ global function Canyonlands_MapInit_Common
 global function CodeCallback_PlayerEnterUpdraftTrigger
 global function CodeCallback_PlayerLeaveUpdraftTrigger
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 	global function HoverTankTestPositions
 
 #endif
@@ -939,7 +939,7 @@ void function HoverTank_DebugFlightPaths_Thread()
 	printt( "++++--------------------------------------------------------------------------------------------------------------------------++++" )
 }
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function HoverTankTestPositions()
 {
 	entity player = GetPlayerArray()[0]
@@ -1106,7 +1106,7 @@ void function OnLeviathanMarkerCreated( entity marker )
 {
 	string markerTargetName = marker.GetTargetName()
 	printt( "OnLeviathanMarkerCreated, targetName: " + markerTargetName  )
-	#if R5DEV
+	#if DEVELOPER
 		if ( IsValid( file.clientSideLeviathan1 ) && markerTargetName == CANYONLANDS_LEVIATHAN1_NAME )
 		{
 			printt( "Destroying clientSideLeviathan1 with markerName: " + markerTargetName  )

--- a/vscripts/mp/levels/mp_rr_canyonlands_mu1_common.nut
+++ b/vscripts/mp/levels/mp_rr_canyonlands_mu1_common.nut
@@ -11,7 +11,7 @@ global function InitOctaneTownTakeover
 global function PlaceOctaneTownTakeoverLoot
 global function CreateOctaneTTRingOfFireStatsTrigger
 
-#if R5DEV
+#if DEVELOPER
 global function LeviathanTeleportBug
 
 global function TestZone6LeviathanFootStomp
@@ -21,7 +21,7 @@ global function DEV_LeviathanAllowRoar
 
 global function TeleportPlayerZeroIntoLeviathanFoot
 global function RecreateLeviathanDeathTriggers
-#endif // R5DEV
+#endif // DEVELOPER
 #endif // SERVER
 
 //global const asset MU1_LEVIATHAN_MODEL = $"mdl/Creatures/leviathan/leviathan_kingscanyon_animated.rmdl"
@@ -1694,7 +1694,7 @@ bool function RelayRockFixEnabled()
 	return GetCurrentPlaylistVarInt( "relay_rock_fix_enabled", 0 ) == 1
 }
 
-#if R5DEV
+#if DEVELOPER
 
 void function LeviathanTeleportBug()
 {
@@ -1904,5 +1904,5 @@ void function RecreateLeviathanDeathTriggers()
 
 
 }
-#endif // if R5DEV
+#endif // DEVELOPER
 #endif // SERVER

--- a/vscripts/mp/sh_gladiator_cards.nut
+++ b/vscripts/mp/sh_gladiator_cards.nut
@@ -53,7 +53,7 @@ global function GladCardDebug
 #endif
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 global function DEV_DumpCharacterCaptures
 global function DEV_GladiatorCards_ToggleForceMoving
 global function DEV_GladiatorCards_ToggleShowSafeAreaOverlay
@@ -233,7 +233,7 @@ global struct CharacterCaptureState
 	void functionref() cleanupSceneFunc
 
 	table<OnStancePIPSlotReadyFuncType, bool> onPIPSlotReadyFuncSet
-	#if R5DEV
+	#if DEVELOPER
 		PakHandle ornull DEV_framePakHandleOrNull = null
 		array<string>    DEV_culprits
 		var              DEV_bgTopo = null
@@ -305,7 +305,7 @@ global struct NestedGladiatorCardHandle
 
 	OnStancePIPSlotReadyFuncType onStancePIPSlotReadyFunc = null
 
-	#if R5DEV
+	#if DEVELOPER
 		string DEV_culprit = ""
 	#endif
 }
@@ -378,7 +378,7 @@ struct FileStruct_LifetimeLevel
 
 		EHI situationPlayer
 
-		#if(R5DEV)
+		#if(DEVELOPER)
 			bool DEV_forceMoving = false
 			bool DEV_showSafeAreaOverlay = false
 			bool DEV_disableCameraAlpha = false
@@ -387,7 +387,7 @@ struct FileStruct_LifetimeLevel
 		array<MenuGladCardPreviewCommand> menuGladCardPreviewCommandQueue
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		bool DEV_forceEnabled = false
 	#endif
 }
@@ -465,7 +465,7 @@ void function ShGladiatorCards_LevelShutdown()
 #if SERVER || CLIENT || UI
 bool function AreGladiatorCardsEnabled()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( fileLevel.DEV_forceEnabled )
 			return true
 	#endif
@@ -485,7 +485,7 @@ NestedGladiatorCardHandle function CreateNestedGladiatorCard( var parentRui, str
 	handle.situation = situation
 	handle.isMoving = eGladCardDisplaySituation_IS_MOVING[situation]
 	//fileLevel.nestedCards.append( handle )
-	#if R5DEV
+	#if DEVELOPER
 		handle.DEV_culprit = expect string(expect table(getstackinfos( 2 )).func)
 	#endif
 
@@ -1074,7 +1074,7 @@ void function UIToClient_HandleMenuGladCardPreviewString( int previewType, int i
 //// Dev functions ////
 ///////////////////////
 ///////////////////////
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_DumpCharacterCaptures()
 {
 	foreach( string key, CharacterCaptureState ccs in fileLevel.ccsMap )
@@ -1087,7 +1087,7 @@ void function DEV_DumpCharacterCaptures()
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_GladiatorCards_ToggleForceMoving( bool ornull forceTo = null )
 {
 	fileLevel.DEV_forceMoving = (forceTo != null ? expect bool(forceTo) : !fileLevel.DEV_forceMoving)
@@ -1095,7 +1095,7 @@ void function DEV_GladiatorCards_ToggleForceMoving( bool ornull forceTo = null )
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_GladiatorCards_ToggleShowSafeAreaOverlay( bool ornull forceTo = null )
 {
 	fileLevel.DEV_showSafeAreaOverlay = (forceTo != null ? expect bool(forceTo) : !fileLevel.DEV_showSafeAreaOverlay)
@@ -1111,7 +1111,7 @@ void function DEV_GladiatorCards_ToggleShowSafeAreaOverlay( bool ornull forceTo 
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_GladiatorCards_ToggleCameraAlpha( bool ornull forceTo = null )
 {
 	fileLevel.DEV_disableCameraAlpha = (forceTo != null ? expect bool(forceTo) : !fileLevel.DEV_disableCameraAlpha)
@@ -1119,7 +1119,7 @@ void function DEV_GladiatorCards_ToggleCameraAlpha( bool ornull forceTo = null )
 #endif
 
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_ForceEnableGladiatorCards()
 {
 	fileLevel.DEV_forceEnabled = true
@@ -1201,7 +1201,7 @@ void function OnItemFlavorRegistered_Character( ItemFlavor characterClass )
 		fileLevel.badgeCharacterMap[badge] <- characterClass
 	}
 
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		AddCallback_EntitiesDidLoad( void function() : ( badgeList ) {
 			// these checks need to be done after script init
 			foreach ( ItemFlavor badge in badgeList )
@@ -1288,7 +1288,7 @@ void function OnItemFlavorRegistered_Character( ItemFlavor characterClass )
 		fileLevel.trackerCharacterMap[tracker] <- characterClass
 	}
 
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		AddCallback_EntitiesDidLoad( void function() : ( trackerList, characterClass ) {
 			// these checks need to be done after script init
 			foreach ( ItemFlavor tracker in trackerList )
@@ -1740,7 +1740,7 @@ void function ActualUpdateNestedGladiatorCard( NestedGladiatorCardHandle handle 
 		{
 			Assert( handle.parentRui != null )
 			RuiSetBool( handle.cardRui, "isAlive", isAlive || IsLobby() )
-			#if R5DEV
+			#if DEVELOPER
 				RuiSetBool( handle.cardRui, "devShowSafeAreaOverlay", fileLevel.DEV_showSafeAreaOverlay )
 			#endif
 
@@ -1893,7 +1893,7 @@ void function ManageCharacterCaptureStateForNestedCard( NestedGladiatorCardHandl
 			delete ccs.onPIPSlotReadyFuncSet[handle.onStancePIPSlotReadyFunc]
 
 		ReleaseCharacterCapture( ccs )
-		#if R5DEV
+		#if DEVELOPER
 			ccs.DEV_culprits.fastremovebyvalue( string(handle) + " " + handle.DEV_culprit )
 		#endif
 		handle.characterCaptureStateOrNull = null
@@ -1902,7 +1902,7 @@ void function ManageCharacterCaptureStateForNestedCard( NestedGladiatorCardHandl
 	{
 		Assert( handle.characterCaptureStateOrNull == null )
 		handle.characterCaptureStateOrNull = GetOrStartCharacterCapture( handle, handle.startTime + 0.5, handle.currentOwnerEHI, handle.isMoving, expect ItemFlavor(characterOrNull), expect ItemFlavor(skinOrNull), frameOrNull, expect ItemFlavor(stanceOrNull) )
-		#if R5DEV
+		#if DEVELOPER
 			CharacterCaptureState ccs = expect CharacterCaptureState(handle.characterCaptureStateOrNull)
 			ccs.DEV_culprits.append( string(handle) + " " + handle.DEV_culprit )
 		#endif
@@ -1972,7 +1972,7 @@ void function DoGladiatorCardCharacterCapture( CharacterCaptureState ccs )
 	EndSignal( ccs, "StopGladiatorCardCharacterCapture" )
 
 	bool doMoving = ccs.isMoving && GladiatorCardStance_HasMovingAnimSeq( ccs.stance )
-	#if R5DEV
+	#if DEVELOPER
 		if ( fileLevel.DEV_forceMoving )
 		{
 			doMoving = true
@@ -2019,7 +2019,7 @@ void function DoGladiatorCardCharacterCapture( CharacterCaptureState ccs )
 	FlagWait( "EntitiesDidLoad" )
 	WaitEndFrame() // this wait is important so the nested gladcard handle can add its onStancePIPSlotReadyFunc
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( fileLevel.DEV_disableCameraAlpha && ccs.frameOrNull != null )
 		{
 			string frameRpakPath     = ItemFlavor_GetHumanReadableRef( expect ItemFlavor( ccs.frameOrNull ) )
@@ -2076,7 +2076,7 @@ void function DoGladiatorCardCharacterCapture( CharacterCaptureState ccs )
 			light.SetTweakLightDistance( 2.0 ) // make distance small to reduce impact of light
 		}
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( ccs.DEV_bgRui != null )
 				RuiDestroyIfAlive( ccs.DEV_bgRui )
 			if ( ccs.DEV_bgTopo != null )
@@ -2085,7 +2085,7 @@ void function DoGladiatorCardCharacterCapture( CharacterCaptureState ccs )
 
 		if ( ccs.colorCorrectionLayer != -1 )
 		{
-			#if(R5DEV)
+			#if(DEVELOPER)
 				Assert( ccs.colorCorrectionLayer != GetBloodhoundColorCorrectionID(), "gladiator cards tried to release bloodhounds color correction. Related to bug R5DEV-75937. Assign bug to Roger A please." )
 			#endif
 			ColorCorrection_Release( ccs.colorCorrectionLayer )
@@ -2177,7 +2177,7 @@ void function DoGladiatorCardCharacterCapture( CharacterCaptureState ccs )
 
 	float farZ = 642.0
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( fileLevel.DEV_disableCameraAlpha && ccs.frameOrNull != null )
 		{
 			float ruiWidth       = 528.0
@@ -2624,7 +2624,7 @@ void function OnPlayerLifestateChanged( entity player, int oldLifeState, int new
 {
 	TriggerUpdateOfNestedGladiatorCardsForPlayer( player )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( GetLocalClientPlayer() == player && !AreGladiatorCardsEnabled() )
 			player.ClientCommand( "devmenu_alias \"features/GladCards/Force enable (if disabled)\"   \"script_client DEV_ForceEnableGladiatorCards()\"" )
 	#endif
@@ -3278,7 +3278,7 @@ string function GladiatorCardStatTracker_GetFormattedValueText( entity player, I
 #if CLIENT
 void function ShGladiatorCards_OnDevnetBugScreenshot()
 {
-	#if R5DEV
+	#if DEVELOPER
 		DEV_DumpCharacterCaptures()
 	#endif
 }

--- a/vscripts/mp/sh_quickchat.gnut
+++ b/vscripts/mp/sh_quickchat.gnut
@@ -19,9 +19,9 @@ global function PlaySoundForCommsAction
 global function HandleBroadcastCommsAction
 #endif
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_ReloadCommsTable
-#endif // DEV
+#endif // DEVELOPER
 
 global enum eCommsFlags
 {
@@ -735,7 +735,7 @@ string function GetPlayerDialogSound( entity player, int index, CommsOptions opt
 		ext = ""
 
 	string result = GetBattleChatterAlias1P3P( player, (subAlias + ext), options.isFirstPerson )
-	#if R5DEV
+	#if DEVELOPER
 		if ( ShouldTryToReplaceMissingVoiceWithTempVoice() )
 		{
 			if ( !DoesAliasExist( result ) )

--- a/vscripts/mp/sh_respawn_beacon.gnut
+++ b/vscripts/mp/sh_respawn_beacon.gnut
@@ -8,7 +8,7 @@ global function GetRespawnStyle
 global function RespawnBeacons_OnSquadEliminated
 global function RespawnBeacon_PutPlayerInDropship
 global function AddCallback_OnDNAPickupDestroyed
-#if R5DEV
+#if DEVELOPER
 global function RespawnPlayersInDropship
 global function RespawnPlayersInDropshipAtPoint
 global function RespawnPlayersInDropshipAtPoint2

--- a/vscripts/mp/sh_survival_training.gnut
+++ b/vscripts/mp/sh_survival_training.gnut
@@ -370,7 +370,7 @@ void function PlayerStartsTraining( entity player )
 	player.TakeOffhandWeapon( OFFHAND_TACTICAL )
 	player.TakeOffhandWeapon( OFFHAND_ULTIMATE )
 
-	#if R5DEV
+	#if DEVELOPER
 	if ( GetBugReproNum() == 2020 )
 	{
 		thread SlideDownHillAnimRecord( player )
@@ -616,7 +616,7 @@ void function TrainingNPCRecordedAnim( entity npc, asset animAsset, asset animAs
 	//wait GetRecordedAnimationDuration( anim )
 }
 
-#if R5DEV
+#if DEVELOPER
 void function SlideDownHillAnimRecord( entity player )
 {
 	wait 1.0

--- a/vscripts/pilot/_leeching.gnut
+++ b/vscripts/pilot/_leeching.gnut
@@ -179,7 +179,7 @@ void function DoLeech( entity self, entity leecher )
 			OnSonarTriggerLeaveInternal( trigger, self )
 		}
 
-		#if R5DEV
+		#if DEVELOPER
 		// if crosshair spawned, switch squad so he isn't mixed in a squad with opposing team spectres
 		string squadname = expect string( self.kv.squadname )
 		// if ( squadname.find( "crosshairSpawnSquad" ) != null ) // throws an error because squadname.find returns an int and you can't compare that to null

--- a/vscripts/pilot/cl_pilot_tracking_vision.gnut
+++ b/vscripts/pilot/cl_pilot_tracking_vision.gnut
@@ -356,7 +356,7 @@ void function TrackingVision_UpdateWaypointPOIDrawing( entity waypoint )
 	if ( !IsValid( localViewPlayer ) )
 		return
 
-#if R5DEV
+#if DEVELOPER
 	if ( localViewPlayer != file.currentTracker )
 	{
 		ResetWaypointVisibilities()

--- a/vscripts/sh_anim_windows.gnut
+++ b/vscripts/sh_anim_windows.gnut
@@ -227,7 +227,7 @@ void function AnimWindow_CreateProp_Start( ScriptAnimWindow window, var settings
 		file.createPropScriptCallbackMap[scriptCallbackKey]( window, settingsBlock, prop )
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		disableoverwrite( windowPropMap )
 	#endif
 	windowPropMap[window.stringID] <- prop
@@ -335,7 +335,7 @@ void function AnimWindow_PlaySound_Start( ScriptAnimWindow window, var settingsB
 		}
 		var soundHandle = EmitSoundOnEntity( window.ent, soundEventName )
 
-		#if R5DEV
+		#if DEVELOPER
 			disableoverwrite( windowSoundHandleMap )
 		#endif
 		windowSoundHandleMap[window.stringID] <- soundHandle
@@ -450,7 +450,7 @@ void function AnimWindow_PlayFX_Start( ScriptAnimWindow window, var settingsBloc
 		}
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		disableoverwrite( windowFXHandleMap )
 	#endif
 
@@ -699,7 +699,7 @@ void function RegisterAnimWindowType( bool isForThisVM, string type,
 	awti.startFunc = startFunc
 	awti.transitionFunc = transitionFunc
 	awti.stopFunc = stopFunc
-	#if R5DEV
+	#if DEVELOPER
 		disableoverwrite( fileLevel.animWindowTypeNameInfoMap )
 	#endif
 	fileLevel.animWindowTypeNameInfoMap[type] <- awti

--- a/vscripts/sh_apex_screens.nut
+++ b/vscripts/sh_apex_screens.nut
@@ -7,7 +7,7 @@ global function SvApexScreens_HighlightPlayerForImpressiveKill
 global function SvApexScreens_HighlightPlayerForKillSpree
 #endif
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 global function DEV_ApexScreens_SetMode
 global function DEV_ApexScreens_TogglePreviewMode
 global function DEV_ApexScreens_GladCardPreviewMode
@@ -25,7 +25,7 @@ global function ServerToClient_ApexScreenRefreshAll
 global function ClApexScreens_OnStaticPropRuiVisibilityChange
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 global function DEV_CreatePerfectApexScreen
 global function DEV_ToggleActiveApexScreenDebug
 global function DEV_ToggleFloatyBitsPrototype
@@ -191,7 +191,7 @@ struct ApexScreenJob
 
 
 struct {
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		bool DEV_inDebugPreviewMode = false
 	#endif
 
@@ -385,7 +385,7 @@ void function SetupScreenOverrides()
 #if SERVER
 void function SvApexScreens_ForceShowSquad( EncodedEHandle ply0, EncodedEHandle ply1, EncodedEHandle ply2 )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.DEV_inDebugPreviewMode )
 			return
 	#endif
@@ -401,7 +401,7 @@ void function SvApexScreens_ForceShowSquad( EncodedEHandle ply0, EncodedEHandle 
 #if SERVER
 void function SvApexScreens_ShowCircleState()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.DEV_inDebugPreviewMode )
 			return
 	#endif
@@ -417,7 +417,7 @@ void function SvApexScreens_ShowCircleState()
 #if SERVER
 void function SvApexScreens_HighlightPlayerForImpressiveKill( entity player, int damageSourceID, float distanceBetweenPlayers, int killedPlayerGrade, entity killedPlayer )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.DEV_inDebugPreviewMode )
 			return
 	#endif
@@ -436,7 +436,7 @@ void function SvApexScreens_HighlightPlayerForImpressiveKill( entity player, int
 #if SERVER
 void function SvApexScreens_HighlightPlayerForKillSpree()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.DEV_inDebugPreviewMode )
 			return
 	#endif
@@ -508,7 +508,7 @@ void function ApexScreenMasterThink()
 	if ( !GetCurrentPlaylistVarBool( "enable_apex_screens", true ) )
 		return
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.DEV_inDebugPreviewMode )
 			return
 	#endif
@@ -638,7 +638,7 @@ void function ApexScreenMasterThink()
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function DEV_ApexScreens_TogglePreviewMode()
 {
 	file.DEV_inDebugPreviewMode = !file.DEV_inDebugPreviewMode
@@ -647,7 +647,7 @@ void function DEV_ApexScreens_TogglePreviewMode()
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function DEV_ApexScreens_GladCardPreviewMode()
 {
 	file.DEV_inDebugPreviewMode = true
@@ -667,7 +667,7 @@ void function DEV_ApexScreens_GladCardPreviewMode()
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function DEV_ApexScreens_SetMode( var opt = "random" )
 {
 	int currentMode = GetGlobalNetInt( "ApexScreensMasterState_Pos1_ModeIndex" ) // just use center screen
@@ -892,7 +892,7 @@ void function ClApexScreens_OnStaticPropRuiVisibilityChange( array<int> newlyVis
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_ToggleActiveApexScreenDebug()
 {
 	file.DEV_activeScreenDebug = !file.DEV_activeScreenDebug
@@ -931,7 +931,7 @@ void function DEV_ActiveApexScreenDebugThread()
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_ToggleFloatyBitsPrototype()
 {
 	file.DEV_isFloatyBitsPrototypeEnabled = !file.DEV_isFloatyBitsPrototypeEnabled
@@ -1299,7 +1299,7 @@ var function CreateApexScreenRUIElement( ApexScreenState screen )
 	var rui
 	if ( screen.magicId == -1 )
 	{
-		#if R5DEV
+		#if DEVELOPER
 			float aspectRatio = 1.0//0.38
 			float height      = screen.diagonalSize / sqrt( 1.0 + pow( aspectRatio, 2.0 ) )
 			float width       = aspectRatio * height
@@ -1379,7 +1379,7 @@ var function CreateApexScreenRUIElement( ApexScreenState screen )
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_CreatePerfectApexScreen( vector origin, float diagonalSize, int screenPosition )
 {
 	ApexScreenState apexScreen

--- a/vscripts/sh_battlepass.gnut
+++ b/vscripts/sh_battlepass.gnut
@@ -58,7 +58,7 @@ global function GetStringForBattlePassReward
 global function ShouldBattlePassTabBeEnabled
 #endif
 
-#if R5DEV && CLIENT || UI
+#if DEVELOPER && CLIENT || UI
 global function DEV_BattlePass
 #endif
 
@@ -412,7 +412,7 @@ int function GetPlayerBattlePassXPProgress( EHI playerEHI, ItemFlavor pass, bool
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -434,7 +434,7 @@ int function GetPlayerBattlePassLastSeenXP( EHI playerEHI, ItemFlavor pass )
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -455,7 +455,7 @@ int function GetPlayerBattlePassPurchasedXP( EHI playerEHI, ItemFlavor pass, boo
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -479,7 +479,7 @@ int function GetPlayerBattlePassEarnedXP( EHI playerEHI, ItemFlavor pass, bool g
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -497,7 +497,7 @@ bool function GetPlayerBattlePassLastSeenPremium( EHI playerEHI, ItemFlavor pass
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return false
 	#endif
@@ -516,7 +516,7 @@ int function GetPlayerBattlePassPurchasedLevels( EHI playerEHI, ItemFlavor pass 
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -596,7 +596,7 @@ int function GetPlayerBattlePassLevel( entity player, ItemFlavor pass, bool getP
 #if SERVER || CLIENT || UI
 int function GetPlayerBattlePassCharacterXP( entity player, ItemFlavor pass, ItemFlavor character )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 1
 	#endif
@@ -676,7 +676,7 @@ array<BattlePassReward> function GetBattlePassLevelRewards( ItemFlavor pass, int
 		rowIndex++
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		foreach( BattlePassReward reward in rewardList )
 		{
 			Assert( reward.quantity > 0, "Invalid BattlePass reward quantity for level " + levelIndex )
@@ -725,7 +725,7 @@ int function GetBattlePassXPEventValue( entity player, int xpType )
 		return 0
 	expect ItemFlavor(activeBattlePass)
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -739,7 +739,7 @@ int function GetBattlePassXPEventValue( entity player, int xpType )
 #if SERVER || CLIENT || UI
 int function GetBattlePassXPEventCount( entity player, int xpType )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -870,7 +870,7 @@ string function GetBattlePassXPEventValueDisplay( entity player, int xpType )
 //// Dev functions ////
 ///////////////////////
 ///////////////////////
-#if R5DEV && CLIENT || UI 
+#if DEVELOPER && CLIENT || UI 
 ItemFlavor function DEV_BattlePass( EHI playerEHI = EHI_null )
 {
 	#if SERVER

--- a/vscripts/sh_bird_cluster.nut
+++ b/vscripts/sh_bird_cluster.nut
@@ -2,7 +2,7 @@ global function BirdClusterSharedInit
 
 #if SERVER
 	global function BirdClusterManager
-	#if R5DEV
+	#if DEVELOPER
 		global function ClusterDebug
 		global function DEV_CreateBirdCluster
 		global function AddFakeCluster
@@ -63,7 +63,7 @@ struct
 {
 	#if SERVER
 		array< BirdCluster > birdClusterArray
-		#if R5DEV
+		#if DEVELOPER
 			array<WaypointClusterInfo> fakeClusters
 		#endif //DEV
 	#endif //SERVER
@@ -93,7 +93,7 @@ void function BirdClusterSharedInit()
 void function BirdCluster_OnGameStateEnter_WaitingForPlayers()
 {
 	thread BirdClusterManager()
-	#if R5DEV
+	#if DEVELOPER
 		thread ClusterDebug()
 	#endif
 }
@@ -159,7 +159,7 @@ array<WaypointClusterInfo> function GetNewWaypointClusters( entity player, int m
 	array<WaypointClusterInfo> clusterArray
 
 	array<WaypointClusterInfo> waypointClusterArray = GetServerWaypointClusters( playerOrigin, CLUSTER_MAX_DIST, minCount, player.GetTeam() )
-	#if R5DEV
+	#if DEVELOPER
 	if ( CLUSTER_USE_FAKE )
 		waypointClusterArray = file.fakeClusters
 	#endif
@@ -387,7 +387,7 @@ vector function GetFlightAngles( vector perchPosition, entity player )
 		TraceResults result = TraceLine( perchPosition, traceOrigin, null, TRACE_MASK_SOLID, TRACE_COLLISION_GROUP_NONE )
 		frac = result.fraction
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( CLUSTER_DEBUG_CLUSTER && player == GP() )
 			{
 				DebugDrawText( traceOrigin, string( trace ), false, 3 )
@@ -517,7 +517,7 @@ int function GetNumberOfBirdClustersBirds()
 }
 #endif //SERVER
 
-#if R5DEV && SERVER
+#if DEVELOPER && SERVER
 void function DEV_CreateBirdCluster( entity owner = null )
 {
 	entity viewPlayer = GP()
@@ -551,7 +551,7 @@ void function ClusterDebug()
 	{
 		// get more or less all clusters in the map
 		array<WaypointClusterInfo> waypointClusterArray = GetServerWaypointClusters( <0,0,0>, 50000, 1, TEAM_UNASSIGNED )
-		#if R5DEV
+		#if DEVELOPER
 		if ( CLUSTER_USE_FAKE )
 			waypointClusterArray = file.fakeClusters
 		#endif

--- a/vscripts/sh_challenges.gnut
+++ b/vscripts/sh_challenges.gnut
@@ -20,7 +20,7 @@ global function Challenge_GetProgressValue
 global function Challenge_GetSource
 global function Challenge_GetStatRefs
 global function Challenge_GetTimeSpan
-#if R5DEV
+#if DEVELOPER
 global function Challenge_GetTierDataBlock
 global function Challenge_GetCharacterItemFlavors
 #endif
@@ -43,7 +43,7 @@ global function RegisterChallengeFromAsset
 #if SERVER
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 global function PrintAllChallenges
 #endif
 
@@ -240,7 +240,7 @@ ItemFlavor ornull function RegisterChallengeFromAsset( asset challengeAsset )
 #if SERVER || CLIENT || UI
 void function ShChallenges_LevelInit_PostStats()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return
 	#endif
@@ -558,7 +558,7 @@ PlayerChallengesState function GetPlayerChallengesState( entity player = null )
 #if SERVER || CLIENT || UI
 void function InitPlayerChallengesStateFromPersistence( entity player, PlayerChallengesState pcs )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return
 	#endif
@@ -639,7 +639,7 @@ void function InitPlayerChallengesStateFromPersistence( entity player, PlayerCha
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function PrintAllChallenges()
 {
 	array<ItemFlavor> allChallenges = GetAllChallenges()
@@ -1285,7 +1285,7 @@ array<ItemFlavor> function GetAllChallengesOfTimespan( int timeSpan, int weekInd
 #if SERVER || CLIENT || UI
 int function Challenge_GetCurrentTier( entity player, ItemFlavor flavor )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif
@@ -1528,7 +1528,7 @@ int function Challenge_GetProgressValue( entity player, ItemFlavor challengeFlav
 	Assert( ItemFlavor_GetType( challengeFlav ) == eItemType.challenge )
 	Assert( tier >= 0 && tier < Challenge_GetTierCount( challengeFlav ) )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return 0
 	#endif

--- a/vscripts/sh_character_cosmetics.nut
+++ b/vscripts/sh_character_cosmetics.nut
@@ -46,7 +46,7 @@ global function CharacterIntroQuip_GetSortOrdinal
 global function CharacterSkin_Apply
 global function CharacterSkin_WaitForAndApplyFromLoadout
 #endif
-#if R5DEV && CLIENT
+#if DEVELOPER && CLIENT
 global function DEV_TestCharacterSkinData
 #endif
 
@@ -761,7 +761,7 @@ asset function CharacterSkydiveEmote_GetVideo( ItemFlavor flavor )
 }
 
 
-#if R5DEV && CLIENT
+#if DEVELOPER && CLIENT
 void function DEV_TestCharacterSkinData()
 {
 	entity model = CreateClientSidePropDynamic( <0, 0, 0>, <0, 0, 0>, $"mdl/dev/empty_model.rmdl" )
@@ -779,4 +779,4 @@ void function DEV_TestCharacterSkinData()
 
 	model.Destroy()
 }
-#endif // DEV && CLIENT
+#endif // DEVELOPER && CLIENT

--- a/vscripts/sh_characters.gnut
+++ b/vscripts/sh_characters.gnut
@@ -105,7 +105,7 @@ void function ShCharacters_LevelInit()
 	FileStruct_LifetimeLevel newFileGame
 	fileLevel = newFileGame
 
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		AddCallback_GeneratePDef( GenerateCharactersPDef )
 	#endif
 
@@ -191,7 +191,7 @@ void function OnItemFlavorRegistered_Character( ItemFlavor character )
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateCharactersPDef()
 {
 	// this persistent data enum is required by sh_xp.gnut

--- a/vscripts/sh_clientmusic.gnut
+++ b/vscripts/sh_clientmusic.gnut
@@ -8,9 +8,9 @@ global function ClientMusic_StopCustomTrackOnClient
 
 #if CLIENT
 global function ClientMusic_RequestStingerForNewZone
-#if R5DEV
+#if DEVELOPER
 global function ClientMusic_PrintStatus
-#endif // #if R5DEV
+#endif // #if DEVELOPER
 #endif // CLIENT
 
 #if SERVER
@@ -369,19 +369,19 @@ void function ClientMusicFrameThread()
 
 	while ( true )
 	{
-#if R5DEV
+#if DEVELOPER
 		float preFrameTime = Time()
-#endif // DEV
+#endif // DEVELOPER
 
 		s_inFrame = true
 		s_lastFrameTime = Time()
 		ClientMusicFRAME()
 		s_inFrame = false
 
-#if R5DEV
+#if DEVELOPER
 		float postFrameTime = Time()
 		Assert( preFrameTime == postFrameTime, format( "ClientMusicFRAME() stalled for %.2f seconds. Should have no waits.", (postFrameTime - preFrameTime) ) )
-#endif // DEV
+#endif // DEVELOPER
 
 		s_inLoopWaitFrame = true
 		WaitFrame()
@@ -389,13 +389,13 @@ void function ClientMusicFrameThread()
 	}
 }
 
-#if R5DEV
+#if DEVELOPER
 void function ClientMusic_PrintStatus()
 {
 	printf( "running: %s, mid-frame: %s, in-waitframe: %s, startTime: %.2f, lastFrameTime: %.2f, timeNow: %.2f", (s_isRunning ? "yes" : "no"), (s_inFrame ? "yes" : "no"), (s_inLoopWaitFrame ? "yes" : "no"), s_startTime, s_lastFrameTime, Time() )
 	printf( "status: %s", GetClientMusicStatusLine() )
 }
-#endif // #if R5DEV
+#endif // #if DEVELOPER
 
 string function GetDebugNameForMusicLevel( int musicLevel )
 {
@@ -417,13 +417,13 @@ string function GetDebugNameForMusicTrack( int musicTrack )
 	return ""
 }
 
-#if R5DEV
+#if DEVELOPER
 string function GetClientMusicStatusLine()
 {
 	//	 = musicTrack
 	return format( "'%s',   latest - %s::'%s'", GetDebugNameForMusicLevel( s_musicLevel ), GetDebugNameForMusicTrack( s_lastPlayedMuscTrackDEBUG ), s_lastPlayedAliasDEBUG )
 }
-#endif // #if R5DEV
+#endif // #if DEVELOPER
 #endif // CLIENT
 
 const string FUNCNAME_CLIENTMUSICDISABLE = "ClientMusic_DisableForClient"

--- a/vscripts/sh_codecallbacks.gnut
+++ b/vscripts/sh_codecallbacks.gnut
@@ -662,7 +662,7 @@ void function ServerCallback_PlayerChangedTeams( entity player, int oldTeam, int
 	foreach( void functionref(entity, int, int) callbackFunc in s_callbacksOnPlayerChangedTeam )
 		callbackFunc( player, oldTeam, newTeam )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( oldTeam == TEAM_INVALID || newTeam == TEAM_INVALID )
 			return
 

--- a/vscripts/sh_damage_types.nut
+++ b/vscripts/sh_damage_types.nut
@@ -411,7 +411,7 @@ void function DamageTypes_Init()
 
 	PrecacheWeapon( $"mp_weapon_rspn101" ) // used by npc_soldier ><
 
-#if R5DEV
+#if DEVELOPER
 
 	int numDamageDefs = DamageDef_GetCount()
 	table damageSourceIdEnum = expect table( getconsttable().eDamageSourceId )
@@ -572,7 +572,7 @@ void function DamageTypes_Init()
 		,[ eDamageSourceId.mp_weapon_shadow_squad_hands_primary ] 	= "#DEATH_MELEE_SHADOWSQUAD_HANDS"
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		//development, with retail versions incase a rare bug happens we dont want to show developer text
 		file.damageSourceIDToName[ eDamageSourceId.damagedef_unknownBugIt ] 			= "UNKNOWN! BUG IT!"
 		file.damageSourceIDToName[ eDamageSourceId.damagedef_unknown ] 				= "Unknown"

--- a/vscripts/sh_death_hints.gnut
+++ b/vscripts/sh_death_hints.gnut
@@ -107,7 +107,7 @@ void function DeathHints_Init()
 		string locString = GetDataTableString( dataTable, i, locStringColumn )
 		string mapName = GetDataTableString( dataTable, i, mapNameColumn )
 
-		#if R5DEV
+		#if DEVELOPER
 		if ( !( sourceName in eHints ) )
 		{
 			Warning( "Unhandled death hint source " + sourceName )

--- a/vscripts/sh_doors.nut
+++ b/vscripts/sh_doors.nut
@@ -14,7 +14,7 @@ global function IsCodeDoor
 global function IsDoorOpen
 global function GetAllPropDoors
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 global function DEV_RestartAllDoorThinks
 #endif
 
@@ -45,7 +45,7 @@ struct DoorData
 
 struct
 {
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		table<entity, int> allDoors
 	#endif
 
@@ -80,7 +80,7 @@ void function ShDoors_Init()
 
 		file.propDoorArrayIndex = CreateScriptManagedEntArray()
 
-		#if R5DEV
+		#if DEVELOPER
 			RegisterSignal( "HaltDoorThink" )
 			AddClientCommandCallback( "dev_spawn_blockable_door", ClientCommand_dev_spawn_blockable_door )
 		#endif
@@ -145,7 +145,7 @@ array<entity> function GetAllPropDoors()
 	#endif //CLIENT
 }
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 bool function ClientCommand_dev_spawn_blockable_door( entity player, array<string> args )
 {
 	TraceResults tr = TraceLine(
@@ -165,7 +165,7 @@ bool function ClientCommand_dev_spawn_blockable_door( entity player, array<strin
 }
 #endif
 
-//#if SERVER && R5DEV
+//#if SERVER && DEVELOPER
 //void function CreateDoor( vector hingeEdgeBottomPos, vector angleToGap, entity existingEnt = null )
 //{
 //	//
@@ -488,13 +488,13 @@ void function OnDoorSpawned( entity door )
 		}
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		file.allDoors[door] <- doorType
 	#endif
 }
 #endif
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function DEV_RestartAllDoorThinks()
 {
 	foreach( entity door, int doorType in file.allDoors )
@@ -632,7 +632,7 @@ void function SurvivalDoorThink( entity door, int doorType )
 	vector defaultAngles = door.GetAngles() //not used by SurvivalDoorPlainThink_Internal
 
 	door.EndSignal( "OnDestroy" )
-	#if R5DEV
+	#if DEVELOPER
 		door.EndSignal( "HaltDoorThink" )
 	#endif
 	OnThreadEnd( function() : ( door, doorType, defaultAngles ) {
@@ -965,7 +965,7 @@ void function OnCodeDoorUsed( entity door, entity player, int useInputFlags )
 void function BlockableDoorThink( entity door )
 {
 	door.EndSignal( "OnDestroy" )
-	#if R5DEV
+	#if DEVELOPER
 		door.EndSignal( "HaltDoorThink" )
 	#endif
 	OnThreadEnd( function() : ( door ) {
@@ -1225,7 +1225,7 @@ void function OperateBlockableDoor( entity door, int goalNotch, entity operator,
 {
 	door.EndSignal( "OnDestroy" )
 	door.EndSignal( "DoorOperating" )
-	#if R5DEV
+	#if DEVELOPER
 		door.EndSignal( "HaltDoorThink" )
 	#endif
 
@@ -1739,7 +1739,7 @@ void function SurvivalDoorSliding_PlayAnimationAndResetSkin( entity doorModel, s
 #if SERVER
 void function SurvivalDoorSlidingThink( entity doorModel )
 {
-	#if R5DEV
+	#if DEVELOPER
 		doorModel.EndSignal( "HaltDoorThink" )
 	#endif
 
@@ -1907,7 +1907,7 @@ void function OnPlayerLeaveSlidingTrigger( entity trigger, entity ent )
 #if SERVER
 void function SurvivalDoorSlidingTriggerEnterThink( entity doorModel, entity trigger, int doorDataIndex )
 {
-	#if R5DEV
+	#if DEVELOPER
 		doorModel.EndSignal( "HaltDoorThink" )
 	#endif
 	trigger.EndSignal( "OnDeath" )
@@ -1935,7 +1935,7 @@ void function SurvivalDoorSlidingTriggerEnterThink( entity doorModel, entity tri
 #if SERVER
 void function SurvivalDoorSlidingTriggerLeaveThink( entity doorModel, entity trigger, int doorDataIndex )
 {
-	#if R5DEV
+	#if DEVELOPER
 		doorModel.EndSignal( "HaltDoorThink" )
 	#endif
 	trigger.EndSignal( "OnDeath" )

--- a/vscripts/sh_elite_streak.gnut
+++ b/vscripts/sh_elite_streak.gnut
@@ -14,7 +14,7 @@ global function ServerCallback_UpdateEliteBadge
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 global function TestEliteStreak
 #endif
 
@@ -174,7 +174,7 @@ void function UpdateEliteBadge( int streak, bool hasAccess, bool animate = true 
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function TestEliteStreak( int streak = 1 )
 {
 	UpdateEliteBadge( streak, true, true )

--- a/vscripts/sh_flag.gnut
+++ b/vscripts/sh_flag.gnut
@@ -41,7 +41,7 @@ struct
 
 void function Flags_Init()
 {
-	#if R5DEV
+	#if DEVELOPER
 		//level.flagHistory <- {}
 	#endif
 
@@ -67,7 +67,7 @@ void function FlagSet( string msg )
 {
 	Assert( msg in shFile.flags, "flag " + msg + " not initialized yet" )
 
-	#if R5DEV
+	#if DEVELOPER
 		//if ( !Flag( msg ) )
 		//	level.flagHistory[ msg ] <- true
 	#endif

--- a/vscripts/sh_flightpath.gnut
+++ b/vscripts/sh_flightpath.gnut
@@ -13,7 +13,7 @@ global function IsActiveNodeAnalysis
 
 global function AddDropshipFlightAnalysis
 
-#if R5DEV && SERVER
+#if DEVELOPER && SERVER
 global function AddNewAnalysis
 #endif
 
@@ -339,7 +339,7 @@ void function EntitiesDidLoad()
 	//	AddAnalysisFunc( flightPath, AnaylsisFuncDropshipFindDropNodes, HULL_HUMAN )
 	//	AddAnalysisIterator( flightPath, 2 ) // iterate every other node
 	//
-	//	#if R5DEV
+	//	#if DEVELOPER
 	//	bool foundDropoffSpawnpoint = FlightPathHasNodeAndMatchesAINData( flightPath )
 	//	#endif
 	//
@@ -349,7 +349,7 @@ void function EntitiesDidLoad()
 	//	AddAnalysisFunc( flightPath, AnaylsisFuncDropshipFindDropNodes, HULL_HUMAN )
 	//	AddAnalysisIterator( flightPath, 2 ) // iterate every other node
 	//
-	//	#if R5DEV
+	//	#if DEVELOPER
 	//	if ( !foundDropoffSpawnpoint )
 	//	{
 	//		if ( !FlightPathHasNodeAndMatchesAINData( flightPath ) && !Flag( "DisableDropships" ) )

--- a/vscripts/sh_flightpath_utility.gnut
+++ b/vscripts/sh_flightpath_utility.gnut
@@ -1429,7 +1429,7 @@ void function ServerCallback_DestroyAirdropBadPlace( int id )
 }
 #endif //CLIENT
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function AirdropTraceTest( entity player )
 {
 	vector startPosition = player.EyePosition() + <0,0,8>

--- a/vscripts/sh_grx.gnut
+++ b/vscripts/sh_grx.gnut
@@ -30,7 +30,7 @@ global function GRX_PurchaseItem
 global function GRXPack_IsExpectedToContainSingleItemWithCurrency
 global function GRXPack_GetTickModel
 global function GRXPack_GetTickModelSkin
-#if CLIENT || UI && R5DEV 
+#if CLIENT || UI && DEVELOPER 
 global function GetItemFlavorByGRXRef
 #endif
 #endif
@@ -96,7 +96,7 @@ global function GRXPack_GetCustomColor
 global function GRXPack_GetCustomCountTextCol
 #endif
 
-#if R5DEV
+#if DEVELOPER
 #if SERVER
 global function DEV_GRX_BulkOpenPacksUsingBots
 #elseif CLIENT
@@ -320,7 +320,7 @@ struct FileStruct_LifetimeVM
 
 	bool WORKAROUND_wasUserInfoUpdatedBeforeLevelInit = false
 
-	#if R5DEV
+	#if DEVELOPER
 		int grxTimeDeltaMinutes = 0
 
 		string grxStorePreviewItem = ""
@@ -336,7 +336,7 @@ struct FileStruct_LifetimeLevel
 	array<ItemFlavor>      packFlavorList
 	table<ItemFlavor, int> currencyIndexMap
 	table<int, ItemFlavor> grxIndexItemFlavorMap
-	#if R5DEV
+	#if DEVELOPER
 		table<string, ItemFlavor> grxRefItemFlavorMap
 	#endif
 
@@ -488,7 +488,7 @@ void function ShGRX_RegisterItemFlavor( ItemFlavor flavor )
 		flavor._____INTERNAL_grxIndex = GRX_RegisterItem( grxRef, flavor._____INTERNAL_grxMode )
 
 		fileLevel.grxIndexItemFlavorMap[flavor._____INTERNAL_grxIndex] <- flavor
-		#if R5DEV
+		#if DEVELOPER
 			fileLevel.grxRefItemFlavorMap[grxRef] <- flavor
 		#endif
 	}
@@ -552,7 +552,7 @@ ItemFlavor function GetItemFlavorByGRXIndex( int index )
 #endif
 
 
-#if CLIENT || UI && R5DEV 
+#if CLIENT || UI && DEVELOPER 
 ItemFlavor function GetItemFlavorByGRXRef( string grxRef )
 {
 	//
@@ -823,7 +823,7 @@ bool function IsItemOwnedByPlayerInternal( ItemFlavor flav, entity player = null
 		#endif
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( EverythingUnlockedConVarEnabled() || GetCurrentPlaylistVarBool( "dev_force_everything_unlocked", false ) )
 			return true
 	#endif
@@ -1455,7 +1455,7 @@ bool function GRX_IsGRXEnabled()
 #endif
 
 
-#if R5DEV && UI
+#if DEVELOPER && UI
 void function DEV_GRX_PrintStoreOfferLocations()
 {
 	foreach ( ItemFlavor itemLocation, ItemFlavorPurchasabilityInfo ifpi in fileLevel.itemFlavorPurchasabilityInfoMap )
@@ -1487,7 +1487,7 @@ void function DEV_GRX_TestOpenPack( string ref = "pack_cosmetic_rare" )
 #endif
 
 
-#if R5DEV && UI
+#if DEVELOPER && UI
 void function DEV_GRX_TestPurchase( string ref = "pack_cosmetic_rare", array<int> price = [1, 0, 0], int qty = 1 )
 {
 	ItemFlavor flav = GetItemFlavorByHumanReadableRef( ref )
@@ -1503,7 +1503,7 @@ void function DEV_GRX_TestPurchase( string ref = "pack_cosmetic_rare", array<int
 #endif
 
 
-#if R5DEV && CLIENT
+#if DEVELOPER && CLIENT
 ItemFlavorBag ornull DEV_GRX_ForcePackResults_resultsOrNull
 void function DEV_GRX_ForcePackResults( int packError, ... )
 {
@@ -1525,7 +1525,7 @@ void function DEV_GRX_ForcePackResults( int packError, ... )
 }
 #endif
 
-#if R5DEV && SERVER
+#if DEVELOPER && SERVER
 void function DEV_GRX_GiveItem( entity bot, int grxidx )
 {
 	//
@@ -1547,7 +1547,7 @@ string function GRX_DBG_PREFIX()
 #endif
 
 
-#if R5DEV && SERVER
+#if DEVELOPER && SERVER
 const int DEV_GRX_BulkOpenPacksUsingBots_numFreshAccounts = 10000
 const int DEV_GRX_BulkOpenPacksUsingBots_numPackOpeningsPerAccount = 505
 string DEV_GRX_BulkOpenPacksUsingBots_persistenceDomain = "uhoh"
@@ -1569,7 +1569,7 @@ void function DEV_GRX_BulkOpenPacksUsingBots()
 	//SpamLog( "$$$$@ DEV_GRX_BulkOpenPacksUsingBots - BEGIN" + "\n" )
 
 	OnThreadEnd( void function() {
-		#if GRX_DEBUG_PRINTS && R5DEV
+		#if GRX_DEBUG_PRINTS && DEVELOPER
 			fileLevel.GRX_DEBUG_PRINTS_disableTemporarily = false
 		#endif
 
@@ -1587,7 +1587,7 @@ void function DEV_GRX_BulkOpenPacksUsingBots()
 	//if ( !Dev_CommandLineHasParm( "-partyDediOnly" ) )
 	//	Dev_CommandLineAddParm( "-partyDediOnly", "-partyDediOnly" )
 
-	#if GRX_DEBUG_PRINTS && R5DEV
+	#if GRX_DEBUG_PRINTS && DEVELOPER
 		fileLevel.GRX_DEBUG_PRINTS_disableTemporarily = true
 	#endif
 
@@ -2286,7 +2286,7 @@ void function UICodeCallback_GRXOffersRefreshed( int offersState, array< GRXCraf
 }
 #endif
 
-#if R5DEV
+#if DEVELOPER
 #if UI
 void function DEV_GRX_SetTimeDelta( int minutes )
 {
@@ -2508,7 +2508,7 @@ void function HandleGRXOffersRefreshed( int offersState, array< GRXCraftingOffer
 		if ( scriptOffer.expireTime > 0 )
 		{
 			scriptOffer.expireTime -= SECONDS_PER_MINUTE * 30 //
-			#if R5DEV
+			#if DEVELOPER
 				scriptOffer.expireTime += (SECONDS_PER_MINUTE * fileVM.grxTimeDeltaMinutes)
 			#endif
 		}
@@ -2735,7 +2735,7 @@ void function ClientCodeCallback_GRXPackOpened( array<int> balanceDiffs, array<i
 		#endif
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_GRX_ForcePackResults_resultsOrNull != null )
 		{
 			printt( "PACK RESULTS FORCED!!" )
@@ -2807,7 +2807,7 @@ void function CodeCallback_GRXPackOpened( entity player, array<int> balanceDiffs
 {
 	//
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( player in DEV_GRX_BulkOpenPacksUsingBots_botPackIndexMap )
 			DEV_GRX_BulkOpenPacksUsingBots_OnPackOpened( player, balanceDiffs, newItems, packError )
 	#endif

--- a/vscripts/sh_grx.gnut
+++ b/vscripts/sh_grx.gnut
@@ -30,7 +30,7 @@ global function GRX_PurchaseItem
 global function GRXPack_IsExpectedToContainSingleItemWithCurrency
 global function GRXPack_GetTickModel
 global function GRXPack_GetTickModelSkin
-#if CLIENT || UI && DEVELOPER 
+#if DEVELOPER && ( CLIENT || UI )
 global function GetItemFlavorByGRXRef
 #endif
 #endif
@@ -552,7 +552,7 @@ ItemFlavor function GetItemFlavorByGRXIndex( int index )
 #endif
 
 
-#if CLIENT || UI && DEVELOPER 
+#if DEVELOPER && ( CLIENT || UI )
 ItemFlavor function GetItemFlavorByGRXRef( string grxRef )
 {
 	//

--- a/vscripts/sh_items.gnut
+++ b/vscripts/sh_items.gnut
@@ -274,7 +274,7 @@ struct FileStruct_LifetimeLevel
 
 	bool isItemRegistrationFinished = false
 
-	#if R5DEV
+	#if DEVELOPER
 		bool DEV_hasItemRegistrationStarted = false
 	#endif
 
@@ -300,7 +300,7 @@ void function ShItems_LevelInit_Begin()
 	FileStruct_LifetimeLevel newFileLevel
 	fileLevel = newFileLevel
 
-	#if R5DEV
+	#if DEVELOPER
 		#if SERVER
 			AddClientCommandCallback( "itemflavors_dump", ClientCommand_itemflavors_dump )
 		#endif
@@ -721,7 +721,7 @@ string function ItemFlavor_GetLongName( ItemFlavor flavor )
 	Assert( IsItemFlavorStructValid( flavor, eValidation.ASSERT ) )
 
 	string localizationKey = GetGlobalSettingsString( flavor._____INTERNAL_settingsAsset, "localizationKey_NAME" )
-	#if R5DEV
+	#if DEVELOPER
 		if ( localizationKey == "" )
 			localizationKey = format( "%s !UNLOCALIZED!", ItemFlavor_GetHumanReadableRef( flavor ) )
 		else if ( localizationKey.slice( 0, 1 ) != "#" )
@@ -738,7 +738,7 @@ string function ItemFlavor_GetShortName( ItemFlavor flavor )
 	Assert( IsItemFlavorStructValid( flavor, eValidation.ASSERT ) )
 
 	string localizationKey = GetGlobalSettingsString( flavor._____INTERNAL_settingsAsset, "localizationKey_NAME_SHORT" )
-	#if R5DEV
+	#if DEVELOPER
 		if ( localizationKey == "" )
 			localizationKey = format( "%s !UNLOCALIZED!", ItemFlavor_GetHumanReadableRef( flavor ) )
 		else if ( localizationKey.slice( 0, 1 ) != "#" )
@@ -755,7 +755,7 @@ string function ItemFlavor_GetLongDescription( ItemFlavor flavor )
 	Assert( IsItemFlavorStructValid( flavor, eValidation.ASSERT ) )
 
 	string localizationKey = GetGlobalSettingsString( flavor._____INTERNAL_settingsAsset, "localizationKey_DESCRIPTION_LONG" )
-	#if R5DEV
+	#if DEVELOPER
 		if ( localizationKey == "" )
 			localizationKey = format( "%s !UNLOCALIZED!", ItemFlavor_GetHumanReadableRef( flavor ) )
 		else if ( localizationKey.slice( 0, 1 ) != "#" )
@@ -772,7 +772,7 @@ string function ItemFlavor_GetShortDescription( ItemFlavor flavor )
 	Assert( IsItemFlavorStructValid( flavor, eValidation.ASSERT ) )
 
 	string localizationKey = GetGlobalSettingsString( flavor._____INTERNAL_settingsAsset, "localizationKey_DESCRIPTION_SHORT" )
-	#if R5DEV
+	#if DEVELOPER
 		if ( localizationKey == "" )
 			localizationKey = format( "%s !UNLOCALIZED!", ItemFlavor_GetHumanReadableRef( flavor ) )
 		else if ( localizationKey.slice( 0, 1 ) != "#" )
@@ -1178,7 +1178,7 @@ string function DEV_DescribeItemFlavorBag( ItemFlavorBag bag )
 const string itemSettingsPathPattern = "^settings/itemflav/([^.]+)\\.rpak$"
 ItemFlavor ornull function RegisterItemFlavorFromSettingsAsset( asset settingsAsset )
 {
-	#if R5DEV
+	#if DEVELOPER
 		fileLevel.DEV_hasItemRegistrationStarted = true
 	#endif
 
@@ -1353,7 +1353,7 @@ ItemFlavor function ItemFlavorBag_GetSingleOutputItemFlavor_Assert( ItemFlavorBa
 ///////////////////
 ///////////////////
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 bool function ClientCommand_itemflavors_dump( entity player, array<string> args )
 {
 	// inv_dump

--- a/vscripts/sh_items_per_player_state.gnut
+++ b/vscripts/sh_items_per_player_state.gnut
@@ -23,7 +23,7 @@ global function ClientToUI_OnItemFlavorBecameNew
 global function Newness_TEMP_MarkItemAsNewAndInformServer
 #endif
 
-#if UI && R5DEV
+#if UI && DEVELOPER
 global function DEV_Newness_ReverseQueryTest
 #endif
 
@@ -80,7 +80,7 @@ void function ShItemPerPlayerState_LevelInit()
 	fileLevel = newFileLevel
 
 	#if SERVER
-		#if R5DEV
+		#if DEVELOPER
 			AddCallback_GeneratePDef( GenerateItemStatePDef )
 		#endif
 		AddClientCommandCallback( "newness_clear", ClientCommand_newness_clear )
@@ -118,7 +118,7 @@ void function Newness_MarkItemFlavorsAsNewForPlayer( entity player, array<ItemFl
 		if ( storedGuid == 0 )
 			continue // empty slot
 
-		#if R5DEV
+		#if DEVELOPER
 			foreach( SettingsAssetGUID otherGuid in guidList )
 			{
 				if ( storedGuid == otherGuid )
@@ -269,7 +269,7 @@ void function Newness_ReverseQuery_Setup(
 #if UI
 void function Newness_AddCallbackAndCallNow_OnRerverseQueryUpdated( Newness_ReverseQuery rq, OnNewnessReverseQueryUpdatedCallbackType cb, var optionalArg = null )
 {
-	#if R5DEV
+	#if DEVELOPER
 		int foundIndex = -1
 		foreach ( int index, OnNewnessReverseQueryUpdatedCallbackStruct cbs in rq.onChangeCallbackList )
 		{
@@ -423,7 +423,7 @@ void function UpdateReverseQueryDependents( array<Newness_ReverseQuery> dependen
 #if UI
 void function OnPersistentDataReady( entity _unused )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return
 	#endif
@@ -483,7 +483,7 @@ void function ClientToUI_OnItemFlavorBecameNew( int guid, bool isNew )
 #endif
 
 
-#if SERVER && R5DEV && !SP
+#if SERVER && DEVELOPER && !SP
 void function GenerateItemStatePDef()
 {
 	DEV_PDefGen_BeginFieldGroup( "item state" )
@@ -493,7 +493,7 @@ void function GenerateItemStatePDef()
 #endif
 
 
-#if UI && R5DEV
+#if UI && DEVELOPER
 void function DEV_Newness_ReverseQueryTest()
 {
 	Newness_ReverseQuery charactersRQ

--- a/vscripts/sh_loadouts.gnut
+++ b/vscripts/sh_loadouts.gnut
@@ -40,7 +40,7 @@ global function RequestSetItemFlavorLoadoutSlot
 global function RequestSetItemFlavorLoadoutSlot_WithDuplicatePrevention
 global function RequestSetItemFlavorFavoritesSlot
 global function RequestClearItemFlavorFavoritesSlot
-#if R5DEV
+#if DEVELOPER
 global function DEV_RequestSetItemFlavorLoadoutSlot
 #endif
 #endif
@@ -57,7 +57,7 @@ global function IsValidLoadoutSlotContentsIndex
 global function GetAllLoadoutSlots
 global function IsLoadoutSlotActive
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_GetValidItemFlavorsForLoadoutSlotForDev
 #endif
 
@@ -77,7 +77,7 @@ global function ClientToUI_RefreshLoadoutSlot
 global function GetLoadoutItemsSortedForMenu
 #endif
 
-//#if CLIENT && R5DEV
+//#if CLIENT && DEVELOPER
 //global function UIToClient_ResendAllCacheData
 //#endif
 
@@ -127,7 +127,7 @@ global struct LoadoutEntry
 	string ornull                                  networkVarName = ""
 	LoadoutEntry_IsSlotLocked                      isSlotLocked = null // optional, default = unlocked
 	table<LoadoutEntry, table<ItemFlavor, bool> >  isActiveConditions = {}
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		LoadoutEntry_IsCurrentlyRelevantFuncType isCurrentlyRelevant = null // optional, default = is relevant (currently only used for dev-menu!) // todo(dw): find a way to be rid of isCurrentlyRelevant and shouldNetwork
 	#endif
 	string DEV_category = "Other"
@@ -148,7 +148,7 @@ global struct LoadoutEntry
 	table<int, ItemFlavor>                              _____INTERNAL_networkIndexItemFlavorMap = {}
 
 	array<string>                                        _____INTERNAL_favoritePdefKeys = []
-	#if R5DEV
+	#if DEVELOPER
 		array<ItemFlavor>      _____INTERNAL_DEV_validItemFlavorsForDev = []
 	#endif
 
@@ -209,14 +209,14 @@ FileStruct_LifetimeLevel& fileLevel
 //// Initialiszation ////
 /////////////////////////
 /////////////////////////
-#if UI && R5DEV
+#if UI && DEVELOPER
 bool DEV_resendAllCacheData = false // for uiscript_reset
 #endif
 
 #if UI
 void function ShLoadouts_VMInit()
 {
-	#if UI && R5DEV
+	#if UI && DEVELOPER
 		if ( IsFullyConnected() )
 			DEV_resendAllCacheData = true
 	#endif
@@ -234,7 +234,7 @@ void function ShLoadouts_LevelInit_Begin()
 		AddCallback_UpgradePlayerPersistentData( UpgradePlayerPersistentData )
 		AddClientCommandCallback( "loadouts_set", ClientCommand_loadouts_set )
 		AddClientCommandCallback( "loadouts_reset_persistent", ClientCommand_loadouts_reset_persistent )
-		#if R5DEV
+		#if DEVELOPER
 			AddCallback_GeneratePDef( GenerateLoadoutsPDef )
 			AddClientCommandCallback( "loadouts_devset", ClientCommand_loadouts_devset )
 			AddClientCommandCallback( "loadouts_dump", ClientCommand_loadouts_dump )
@@ -348,14 +348,14 @@ void function ShLoadouts_LevelInit_Finish()
 
 						ehiss.netVarsLastSeenValuesMap[nvInfo.nvIndex] = new
 
-						#if R5DEV
+						#if DEVELOPER
 							LoadoutEntry ornull found = null
 						#endif
 						foreach( LoadoutEntry entry in nvInfo.usedByEntries )
 						{
 							if ( IsLoadoutSlotCurrentlyNetworked( playerEHI, entry ) )
 							{
-								#if R5DEV
+								#if DEVELOPER
 									Assert( found == null, "Attempted to network two loadout slots using the same network variable name at the same time"
 											+ " (slot 1: \"" + expect LoadoutEntry(found).id + "\", slot 2: \"" + entry.id + "\")." )
 									if ( found != null )
@@ -371,7 +371,7 @@ void function ShLoadouts_LevelInit_Finish()
 					} )
 				#endif
 			}
-			//#if R5DEV
+			//#if DEVELOPER
 			//	foreach( LoadoutEntry& otherEntry in fileLevel.networkVars[fullNetworkVarName] )
 			//	{
 			//		otherEntry.mutuallyExclusiveWith.append( entry )
@@ -438,7 +438,7 @@ void function ShLoadouts_LevelInit_Finish()
 		{
 			Assert( entry.validItemFlavorList.len() > 0, "No item flavors are registered that are valid for loadout slot '" + entry.id + "'" )
 			entry.validItemFlavorList_CopyForRandomizing = clone entry.validItemFlavorList
-			#if R5DEV
+			#if DEVELOPER
 				entry._____INTERNAL_DEV_validItemFlavorsForDev = clone entry.validItemFlavorList
 				//entry.validItemFlavors.randomize()
 			#endif
@@ -467,14 +467,14 @@ void function ShLoadouts_LevelInit_Finish()
 		}
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			Warning( "loadouts_ignore_persistence (ConVar) is enabled" )
 	#endif
 
 	fileLevel.isInitialized = true
 
-	//#if UI && R5DEV
+	//#if UI && DEVELOPER
 	//	if ( DEV_resendAllCacheData )
 	//		RunClientScript( "UIToClient_ResendAllCacheData" ) // for uiscript_reset
 	//#endif
@@ -500,7 +500,7 @@ LoadoutEntry function RegisterLoadoutSlot( int type, string id, string guidStrin
 	Assert( !fileLevel.isInitialized, "Cannot call RegisterLoadoutSlot after initialization has finished." )
 	Assert( type == eLoadoutEntryType.ITEM_FLAVOR || type == eLoadoutEntryType.INTEGER )
 
-	#if R5DEV
+	#if DEVELOPER
 		foreach( LoadoutEntry otherEntry in fileLevel.loadoutSlotEntries )
 			Assert( id != otherEntry.id, "Found loadout slots with the same id: " + id )
 	#endif
@@ -849,7 +849,7 @@ void function RequestClearItemFlavorFavoritesSlot( EHI playerEHI, LoadoutEntry e
 #endif
 
 
-#if (CLIENT || UI) && R5DEV
+#if (CLIENT || UI) && DEVELOPER
 void function DEV_RequestSetItemFlavorLoadoutSlot( EHI playerEHI, LoadoutEntry entry, ItemFlavor itemFlavor )
 {
 	Assert( playerEHI == LocalClientEHI(), "Tried to use DEV_RequestSetLoadoutSlot on a different player" )
@@ -883,7 +883,7 @@ array<ItemFlavor> function GetValidItemFlavorsForLoadoutSlot( EHI playerEHI, Loa
 }
 
 
-#if R5DEV
+#if DEVELOPER
 array<ItemFlavor> function DEV_GetValidItemFlavorsForLoadoutSlotForDev( EHI playerEHI, LoadoutEntry entry )
 {
 	Assert( entry.type == eLoadoutEntryType.ITEM_FLAVOR )
@@ -944,7 +944,7 @@ bool function IsItemFlavorUnlockedForLoadoutSlot( EHI playerEHI, LoadoutEntry en
 
 	//
 
-	#if R5DEV
+	#if DEVELOPER
 		//
 		//if ( GetConVarBool( "loadouts_ignore_grx" ) )
 			//return true
@@ -1012,7 +1012,7 @@ array<LoadoutEntry> function GetAllLoadoutSlots()
 //// Internals ////
 ///////////////////
 ///////////////////
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateLoadoutsPDef()
 {
 	//Assert( !DEV_AreAnyItemflavorsDisabledByPlaylist(), "You cannot regenerate the loadouts persistent data section if you have item flavors disabled by playlist vars! Use playlist survival_dev." )
@@ -1222,7 +1222,7 @@ int function GetLoadoutSlotContentsIndexInternal( EHI playerEHI, LoadoutEntry en
 #if SERVER || CLIENT || UI
 int function GetLoadoutSlotContentsIndexFromPersistence( EHI playerEHI, LoadoutEntry entry, int validationBehavior = eValidation.ASSERT )
 {
-#if R5DEV
+#if DEVELOPER
 	if ( DEV_ShouldIgnorePersistence() )
 	{
 		if ( entry.type == eLoadoutEntryType.ITEM_FLAVOR )
@@ -1323,7 +1323,7 @@ int function GetLoadoutSlotContentsIndexFromCache( EHI playerEHI, LoadoutEntry e
 #if SERVER
 void function SetItemFlavorLoadoutSlotContentsInternal( EHI playerEHI, LoadoutEntry entry, ItemFlavor itemFlavor )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 		{
 			Warning( "loadouts_ignore_persistence is set. Persistent var \"loadouts." + entry.id + "\" will not be saved." )
@@ -1352,7 +1352,7 @@ void function SetItemFlavorLoadoutSlotContentsInternal( EHI playerEHI, LoadoutEn
 #if SERVER
 void function SetIntegerLoadoutSlotContentsInternal( EHI playerEHI, LoadoutEntry entry, int slotContentsIndex )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 		{
 			Warning( "loadouts_ignore_persistence is set. Persistent var \"loadouts." + entry.id + "\" will not be saved." )
@@ -1415,7 +1415,7 @@ void function RefreshLoadoutSlotInternal( EHI playerEHI, LoadoutEntry entry, tab
 			entity player = FromEHI( playerEHI )
 			if ( entry.networkTo == eLoadoutNetworking.PLAYER_GLOBAL )
 			{
-				#if R5DEV
+				#if DEVELOPER
 					foreach( LoadoutEntry otherEntry in fileLevel.networkVars[expect string(entry.networkVarName)].usedByEntries )
 						Assert( otherEntry == entry || !IsLoadoutSlotCurrentlyNetworked( playerEHI, otherEntry ),
 									"Attempted to network two loadout slots using the same network variable name at the same time"
@@ -1625,7 +1625,7 @@ array<ItemFlavor> function GetLoadoutItemsSortedForMenu( LoadoutEntry entry, int
 #endif // UI
 
 
-//#if CLIENT && R5DEV
+//#if CLIENT && DEVELOPER
 //void function UIToClient_ResendAllCacheData()
 //{
 //	if ( !fileLevel.isInitialized )
@@ -1840,7 +1840,7 @@ bool function ValidateAndFixLoadoutSlot( EHI playerEHI, LoadoutEntry entry, bool
 		if ( entry.type == eLoadoutEntryType.ITEM_FLAVOR )
 		{
 			ItemFlavor itemFlavor
-#if R5DEV
+#if DEVELOPER
 			if ( resetToRandom ) // || GetConVarBool( "loadouts_forceRandom" ) )
 			{
 				itemFlavor = GetRandomGoodItemFlavorForLoadoutSlot( playerEHI, entry )
@@ -1857,7 +1857,7 @@ bool function ValidateAndFixLoadoutSlot( EHI playerEHI, LoadoutEntry entry, bool
 		else if ( entry.type == eLoadoutEntryType.INTEGER )
 		{
 			int newSlotContentsIndex
-#if R5DEV
+#if DEVELOPER
 			if ( resetToRandom ) // || GetConVarBool( "loadouts_forceRandom" ) )
 			{
 				int value = RandomIntRangeInclusive( entry.minInteger, entry.maxInteger )
@@ -1903,7 +1903,7 @@ bool function IsLoadoutSlotLocked( EHI playerEHI, LoadoutEntry entry )
 	if ( entry.isSlotLocked == null )
 		return false
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( GetCurrentPlaylistVarBool( "dev_loadout_changeable_at_any_time", false ) )
 			return false
 	#endif
@@ -1966,7 +1966,7 @@ bool function ClientCommand_loadouts_set( entity player, array<string> args )
 }
 #endif
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 bool function ClientCommand_loadouts_devset( entity commandPlayer, array<string> args )
 {
 	// loadouts_devset

--- a/vscripts/sh_loot_ceremony.gnut
+++ b/vscripts/sh_loot_ceremony.gnut
@@ -29,7 +29,7 @@ global function ModelIntroHighlightEffect
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 global function DEV_ShouldShowCustomLootRewards
 global function DEV_SetCustomLootRewardsToDisplay
 #endif
@@ -232,7 +232,7 @@ struct FileLevelStruct
 		array<PakHandle> pakHandles
 	#endif
 
-	#if CLIENT && R5DEV
+	#if CLIENT && DEVELOPER
 		bool           debugShowCustomRewards = false
 		array< asset > debugCustomRewardAssets = [
 			$"settings/itemflav/character_skin/wraith/legendary_01.rpak",
@@ -473,7 +473,7 @@ void function UIToClient_OnGRXPackOpeningResultsAvailable()
 	GRXPackOpened_ErrorHandling( error )
 
 	// populate dev item variables
-	#if R5DEV
+	#if DEVELOPER
 		if ( fileLevel.debugShowCustomRewards )
 		{
 			array< ItemFlavor > debugItems
@@ -710,7 +710,7 @@ void function GRXPackOpened_ErrorHandling( int packError )
 
 	RunUIScript( "OpenConfirmGrxErrorDialog", message )
 
-	#if R5DEV
+	#if DEVELOPER
 		Warning( warningText )
 	#endif
 }
@@ -2729,14 +2729,14 @@ void function ShowRewards_FX( int animAttachID, int rarity, vector rarityColor, 
 #endif
 
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_ShouldShowCustomLootRewards( bool shouldShow )
 {
 	fileLevel.debugShowCustomRewards = shouldShow
 }
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_SetCustomLootRewardsToDisplay( string itemRef0 = "", string itemRef1 = "", string itemRef2 = "" )
 {
 	DEV_ShouldShowCustomLootRewards( true )
@@ -2875,7 +2875,7 @@ void function UIToClient_RewardInspectNavBack()
 #if CLIENT
 void function UIToClient_RewardEquipOnClick()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( fileLevel.debugShowCustomRewards )
 		{
 			Warning( "Trying to equip a reward you may not actually own. You should disable custom rewards." )

--- a/vscripts/sh_map_zones.nut
+++ b/vscripts/sh_map_zones.nut
@@ -33,10 +33,10 @@ global function MapZones_ForceRetouchForPlayer
 
 #endif // SERVER
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 global function DEV_PrintMapZoneInfo
 global function DEV_MapZone_ToggleOverlay
-#endif // SERVER && R5DEV
+#endif // SERVER && DEVELOPER
 
 global struct ZonePopulationInfo
 {
@@ -199,9 +199,9 @@ void function OnClientDisconnected( entity player )
 
 void function EntitiesDidLoad()
 {
-#if R5DEV
+#if DEVELOPER
 	thread DebugFrameThread()
-#endif // DEV
+#endif // DEVELOPER
 
 	if ( !file.mapZonesInitialized )
 		return
@@ -666,7 +666,7 @@ void function SCB_OnPlayerEntersMapZone( int zoneId, int zoneTier )
 
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 string function GetZoneLineForPlayer( entity player )
 {
 	int zoneId = player.p.currentZoneId
@@ -760,4 +760,4 @@ void function DebugFrameThread()
 	}
 }
 
-#endif // #if SERVER && R5DEV
+#endif // #if SERVER && DEVELOPER

--- a/vscripts/sh_menu_models.gnut
+++ b/vscripts/sh_menu_models.gnut
@@ -196,11 +196,11 @@ struct
 
 		array<entity> dimmedEnts
 
-		#if R5DEV
+		#if DEVELOPER
 			bool   DEV_previewSelfAsParty = false
 			string DEV_characterOffsetCharacter = ""
 			vector DEV_characterOffset = <0, 0, 0>
-		#endif // DEV
+		#endif // DEVELOPER
 		int transitionTest = 3
 	#endif // CLIENT
 
@@ -272,7 +272,7 @@ global function GetAttachmentOriginOffset
 
 global function ShMenuModels_ClientToUI_OnMouseWheel
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_TweakPlayCamera
 global function DEV_TweakCharacterCamera
 global function DEV_TweakWeaponCamera
@@ -280,7 +280,7 @@ global function DEV_TogglePreviewParty
 global function DEV_TransitionTest
 global function DEV_ScaleModel
 global function DEV_TweakCharacterOffset
-#endif // DEV
+#endif // DEVELOPER
 
 global function UIToClient_PROTO_UpdateClientWithLocalClientUID
 
@@ -1125,7 +1125,7 @@ void function EnableLobbyMenuCameraZoom()
 
 void function InitMenuEntities()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( BuildingCubeMaps() )
 			return
 	#endif
@@ -1327,7 +1327,7 @@ void function UpdateMenuCharacterModelInternal( int overrideCharacterFlavorNetwo
 		entity refEnt = ModelData_GetPoseEntity( expect MenuModelData( file.presentationData[ file.currentPresentationType ].modelData ) )
 		vector base   = refEnt.GetOrigin()
 		vector offset = CharacterClass_GetGalleryModelOffset( character )
-		#if R5DEV
+		#if DEVELOPER
 			if ( ItemFlavor_GetHumanReadableRef( character ) == file.DEV_characterOffsetCharacter )
 				offset = file.DEV_characterOffset
 		#endif //
@@ -1478,7 +1478,7 @@ void function TrackPartyMembersAndDisplayModelsThread()
 		//Assert( party.amIInThis )
 		string localClientUid = PROTO_GetLocalClientUIDFromUIVM()
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( file.DEV_previewSelfAsParty )
 			{
 				party.members.clear()
@@ -1491,7 +1491,7 @@ void function TrackPartyMembersAndDisplayModelsThread()
 					party.members.append( fakeMember )
 				}
 			}
-		#endif // DEV
+		#endif // DEVELOPER
 
 		foreach( PartyMember partyMemberInfo in party.members )
 		{
@@ -1549,7 +1549,7 @@ void function TrackPartyMembersAndDisplayModelsThread()
 				shouldCreateModel = true
 
 				ItemFlavor ornull characterOrNull = null
-				#if R5DEV
+				#if DEVELOPER
 					if ( file.DEV_previewSelfAsParty )
 						characterOrNull = LoadoutSlot_GetItemFlavor( LocalClientEHI(), Loadout_CharacterClass() )
 				#endif
@@ -2594,7 +2594,7 @@ void function TransitionTest( entity model, vector color, bool doTransitionFX, b
 	}
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_TweakPlayCamera( vector origin, vector angles, float fov )
 {
 	file.playCameraTarget.SetOrigin( origin )
@@ -2649,7 +2649,7 @@ void function DEV_TweakCharacterOffset( string character, vector offset )
 	file.DEV_characterOffsetCharacter = character
 	file.DEV_characterOffset = offset
 }
-#endif // DEV
+#endif // DEVELOPER
 #endif // CLIENT
 
 #if UI
@@ -3069,7 +3069,7 @@ void function SpawnShadowEyeEffects()
 }
 
 
-#if R5DEV
+#if DEVELOPER
 void function DrawLightDebug( vector origin, vector angles, vector color, float dist )
 {
 	vector endOrigin = origin + AnglesToForward( angles ) * dist

--- a/vscripts/sh_mp_utility_all.gnut
+++ b/vscripts/sh_mp_utility_all.gnut
@@ -118,7 +118,7 @@ int function GetAvailableFDUnlockPoints( entity player, string titanClass )
 }
 
 #if SERVER
-	#if R5DEV
+	#if DEVELOPER
 	void function DEV_AddCredits( int additionalCredits, entity optionalPlayer = null )
 	{
 		array<entity> players

--- a/vscripts/sh_passives.gnut
+++ b/vscripts/sh_passives.gnut
@@ -18,7 +18,7 @@ global function TakePassive
 global function TakeAllPassives
 #endif
 
-#if (SERVER || CLIENT) && R5DEV
+#if (SERVER || CLIENT) && DEVELOPER
 global function DEV_PrintAllPassives
 #endif
 
@@ -263,7 +263,7 @@ void function RemoveCallback_OnPassiveChanged( int passive, void functionref( en
 //// Dev functions ////
 ///////////////////////
 ///////////////////////
-#if (SERVER || CLIENT) && R5DEV
+#if (SERVER || CLIENT) && DEVELOPER
 void function DEV_PrintAllPassives( entity player )
 {
 	for ( int passiveIdx = 0; passiveIdx < ePassives._count; passiveIdx++ )

--- a/vscripts/sh_persistent_data.gnut
+++ b/vscripts/sh_persistent_data.gnut
@@ -15,11 +15,11 @@ global function IsPersistenceBitSet
 global function IsAnyPersistenceBitSet
 #endif
 
-#if SERVER || CLIENT || UI && R5DEV
+#if SERVER || CLIENT || UI && DEVELOPER
 global function DEV_ShouldIgnorePersistence
 #endif
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 global function AddCallback_GeneratePDef
 global function DEV_GeneratePersistentDataDefinitionAutogenSection
 global function DEV_PDefGen_AddEnum
@@ -60,7 +60,7 @@ global function ClientToUI_OnPersistentDataReady
 
 #if SERVER
 global typedef UpgradePlayerPersistentDataCallbackType void functionref( entity player, int oldVersion, int newVersion )
-#if R5DEV
+#if DEVELOPER
 global typedef GeneratePDefCallbackType void functionref()
 #endif
 #endif
@@ -81,7 +81,7 @@ struct FileStruct_LifetimeLevel
 {
 	#if SERVER
 		array<UpgradePlayerPersistentDataCallbackType> upgradePlayerPersistentDataCallbacks
-		#if R5DEV
+		#if DEVELOPER
 			array<GeneratePDefCallbackType> generatePDefCallbacks
 		#endif
 	#endif
@@ -104,7 +104,7 @@ void function ShPersistentData_LevelInit_Begin()
 	fileLevel = newFileLevel
 
 	#if SERVER
-		#if R5DEV
+		#if DEVELOPER
 			AddCallback_GeneratePDef( GenerateBasicPDef )
 			AddClientCommandCallback( "dev_generate_pdef", ClientCommand_dev_generate_pdef )
 		#endif
@@ -119,13 +119,13 @@ void function ShPersistentData_LevelInit_Begin()
 
 void function ShPersistentData_LevelInit_Finish()
 {
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		DEV_CheckAndSaveDevPersistentPlayerDataDefinitionAutogenSection( false )
 	#endif
 }
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateBasicPDef()
 {
 	// Stuff like this should not use PDefGen because it's not dynamic
@@ -155,7 +155,7 @@ void function UpgradeBasicPlayerPersistentData( entity player, int oldVersion, i
 ///////////////////////
 ///////////////////////
 
-#if SERVER || CLIENT || UI && R5DEV
+#if SERVER || CLIENT || UI && DEVELOPER
 bool function DEV_ShouldIgnorePersistence()
 {
 	// return GetConVarBool( "loadouts_ignore_persistence" )
@@ -166,7 +166,7 @@ bool function DEV_ShouldIgnorePersistence()
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function AddCallback_GeneratePDef( GeneratePDefCallbackType cb )
 {
 	Assert( !fileLevel.generatePDefCallbacks.contains( cb ), "Callback already registered" )
@@ -507,7 +507,7 @@ void function DEV_PDefGen_AddField_StructArray_EnumKey( string structName, strin
 	Assert( structName in DEV_PDefGen_structMap, "Field references non-existant struct '" + structName + "'" )
 	DEV_PDefGen_AddField_Internal( structName, name, "[" + keyEnumName + "]", comment )
 }
-#endif // SERVER && R5DEV
+#endif // SERVER && DEVELOPER
 
 
 

--- a/vscripts/sh_ping.gnut
+++ b/vscripts/sh_ping.gnut
@@ -542,7 +542,7 @@ PingTraceResults function DoPingTrace( entity player )
 	}
 	result.tr = tr
 
-	#if R5DEV
+	#if DEVELOPER
 		printf( "PING (%s) -  Dist:%.1f, %s, pos:%s, norm:%s, contents:0x%x", (IsServer() ? "SERVER" : "CLIENT"), result.hitDist, (IsValid( result.hitEnt ) ? ("[" + result.hitEnt + "]   '" + result.hitEnt.GetScriptName() + "'") : ""), string( tr.endPos ), string( tr.surfaceNormal ), tr.contents )
 	#endif
 

--- a/vscripts/sh_playlists.gnut
+++ b/vscripts/sh_playlists.gnut
@@ -20,7 +20,7 @@ global function CanPlaylistFitPartySize
 global function GetModeEmblemImage
 #endif
 
-#if CLIENT || UI && R5DEV
+#if CLIENT || UI && DEVELOPER
 global function PrintPlaylists
 #endif
 
@@ -334,7 +334,7 @@ array<int> function GetEmblemColor( string playlistName )
 }
 #endif
 
-#if CLIENT || UI && R5DEV
+#if CLIENT || UI && DEVELOPER
 void function PrintPlaylists()
 {
 	printt( "=== PLAYLIST NAMES: ===" )

--- a/vscripts/sh_postgame_data.gnut
+++ b/vscripts/sh_postgame_data.gnut
@@ -40,7 +40,7 @@ global enum eGameType
 
 bool function GetPersistentLastGameTypeFlag( entity player, int flag )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return false
 	#endif

--- a/vscripts/sh_ranked.gnut
+++ b/vscripts/sh_ranked.gnut
@@ -74,14 +74,14 @@ global function Ranked_IsPlayerAbandoning
 #if SERVER
 #endif
 
-#if CLIENT && R5DEV 
+#if CLIENT && DEVELOPER 
 global function Ranked_ForceClientError
 #endif
 
 #if CLIENT
 global function ShRanked_RegisterNetworkFunctions
 
-#if R5DEV
+#if DEVELOPER
 global function SetRankedIcon
 #endif
 
@@ -699,7 +699,7 @@ bool function Ranked_IsMatchOverForPlayer( entity player ) //
 
 var function GetRankedPersistenceData( entity player, string persistenceField )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence() )
 			return null
 	#endif
@@ -1127,7 +1127,7 @@ void function RuiFillInRankedLadderPos( var rui, int ladderPosition )
 
 #endif //
 
-#if CLIENT && R5DEV 
+#if CLIENT && DEVELOPER 
 void function Ranked_ForceClientError()
 {
 	thread Ranked_AssertFalse()

--- a/vscripts/sh_scene_capture.gnut
+++ b/vscripts/sh_scene_capture.gnut
@@ -86,7 +86,7 @@ void function EntitiesDidLoad()
 		Assert( room.tweakLights.len() == SCENE_CAPTURE_EXPECTED_TWEAK_LIGHT_COUNT, "Scene capture room does not have the expected four tweak lights" )
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( !didHaveRooms )
 			DEV_AddDevCaptureRooms()
 	#endif
@@ -105,7 +105,7 @@ void function ClSceneCapture_PROTO_AddCaptureRoom( vector center )
 }
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DEV_AddDevCaptureRooms()
 {
 	ClSceneCapture_PROTO_AddCaptureRoom( <0, 0, 10000> )
@@ -131,7 +131,7 @@ bool function IsCaptureRoomAvailable()
 #if CLIENT
 CaptureRoom function ReserveCaptureRoom()
 {
-	//#if R5DEV
+	//#if DEVELOPER
 	//	DEV_AddDevCaptureRooms()
 	//#endif
 	foreach( int roomIndex, CaptureRoom room in file.roomList )
@@ -153,7 +153,7 @@ CaptureRoom function ReserveCaptureRoom()
 #if CLIENT
 CaptureRoom function WaitForReserveCaptureRoom()
 {
-	//#if R5DEV
+	//#if DEVELOPER
 	//	DEV_AddDevCaptureRooms()
 	//#endif
 	while( true )
@@ -180,7 +180,7 @@ void function ReleaseCaptureRoom( CaptureRoom room )
 {
 	Assert( room.inUse, "Attempted to end release a Scene capture room that was not in use." )
 
-	#if R5DEV
+	#if DEVELOPER
 		foreach( entity light in room.tweakLights )
 			Assert( IsValid( light ), "Something deleted a scene capture tweak light!" )
 	#endif

--- a/vscripts/sh_social.gnut
+++ b/vscripts/sh_social.gnut
@@ -18,7 +18,7 @@ global function GetInGameFriendCount
 global function HasCommunityUserPlayedApex
 #endif
 
-#if UI && R5DEV
+#if UI && DEVELOPER
 global function Dev_ToggleInvalidFriendData
 global function Dev_SetFillerFriends
 #endif
@@ -96,7 +96,7 @@ FriendsData function GetFriendsData( bool groupByStatus = false )
 	FriendsData returnData
 	returnData.isValid = friendInfo.isValid
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.invalidFriendData )
 			returnData.isValid = false
 
@@ -244,7 +244,7 @@ bool function HasCommunityUserPlayedApex( CommunityUserInfo cui )
 //// Dev functions ////
 ///////////////////////
 ///////////////////////
-#if UI && R5DEV
+#if UI && DEVELOPER
 array<string> friendNames = [ "Anderson", "Alavi", "Vinson", "Armstrong", "Perera", "Moy", "Messerly", "Davis", "McCord", "Keating",
 	"Grenier", "Abrahamson", "Sanchez", "Medina", "McCoy", "Horn", "Cavallari", "McCandlish", "Alderman", "DeRose" ]
 
@@ -265,7 +265,7 @@ CommunityFriendsData function Dev_GetFakeFriendData()
 #endif
 
 
-#if UI && R5DEV
+#if UI && DEVELOPER
 void function Dev_ToggleInvalidFriendData()
 {
 	file.invalidFriendData = !file.invalidFriendData
@@ -273,7 +273,7 @@ void function Dev_ToggleInvalidFriendData()
 #endif
 
 
-#if UI && R5DEV
+#if UI && DEVELOPER
 void function Dev_SetFillerFriends( int count )
 {
 	file.fillerFriends = count

--- a/vscripts/sh_sp_dialogue.gnut
+++ b/vscripts/sh_sp_dialogue.gnut
@@ -61,9 +61,9 @@ global function CustomSpeakers1ListInit
 #endif //CLIENT
 
 
-#if R5DEV
+#if DEVELOPER
 global function ShouldTryToReplaceMissingVoiceWithTempVoice
-#endif //R5DEV
+#endif // DEVELOPERELOPER
 
 
 //////////////////////
@@ -134,9 +134,9 @@ global const PRIORITY_LOW       = 5
 global const PRIORITY_LOWEST    = 1
 
 
-#if R5DEV
+#if DEVELOPER
 global const string TEMP_VOICE  = "playerM1"
-#endif //R5DEV
+#endif // DEVELOPERELOPER
 
 
 ///////////////////////
@@ -205,9 +205,9 @@ struct
 
 	array<string> validVoices
 
-	#if R5DEV
+	#if DEVELOPER
 		array<string> validPerspectives = ["", "solo", "radio"] // blank perspective means 1p and 3p, solo means additional to-self perspective on top of 1p and 3p
-	#endif //R5DEV
+	#endif // DEVELOPERELOPER
 
 	#if CLIENT
 		var                                devTextDialogueRUI
@@ -246,7 +246,7 @@ void function SPDialogueInit()
 	AddClientCommandCallback( "DialogueFinishedForID", ClientCommand_DialogueFinishedForID )
 	AddClientCommandCallback( "AllDialogueFinished", ClientCommand_AllDialogueFinished )
 
-	#if R5DEV
+	#if DEVELOPER
 		// When a character is loaded from bakery, add their currently registered voice value
 		// to the list of voices to be verified by VerifyExistenceOfNongenericAliases
 		AddCallback_OnItemFlavorRegistered( eItemType.character, OnCharacterRegistered )
@@ -302,7 +302,7 @@ DialogueData function GetDataForAliasId( int index )
 }
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function OnCharacterRegistered( ItemFlavor flavor )
 {
 	var block    = GetSettingsBlockForAsset( CharacterClass_GetSetFile( flavor ) )
@@ -311,7 +311,7 @@ void function OnCharacterRegistered( ItemFlavor flavor )
 	if ( !file.validVoices.contains( voice ) )
 		file.validVoices.append( voice )
 }
-#endif //SERVER && R5DEV
+#endif //SERVER && DEVELOPER
 
 
 #if(CLIENT)
@@ -324,7 +324,7 @@ int function GetAnyAliasIdForName( string dialogueName )
 }
 #endif //
 
-#if CLIENT || !R5DEV
+#if CLIENT || !DEVELOPER
 void function OnCharacterRegistered( ItemFlavor flavor )
 {
 	var block    = GetSettingsBlockForAsset( CharacterClass_GetSetFile( flavor ) )
@@ -424,7 +424,7 @@ void function RegisterCSVDialogue( asset dt )
 
 		string extraPerspective = ((optionalColumnPerspective > -1) ? GetDataTableString( dataTable, i, optionalColumnPerspective ) : "")
 
-		#if SERVER && R5DEV
+		#if SERVER && DEVELOPER
 		Assert( file.validPerspectives.contains( extraPerspective ), "Dialogue name " + name + " has a perspective field, but an invalid perspective. Check the perspective column in the CSV against file.validPerspectives in sh_sp_dialogue.gnut" )
 		#endif
 
@@ -459,7 +459,7 @@ void function RegisterDialogueLine( string name, string alias, int priority, str
 	if ( vduVideo != $"" )
 		Assert( radioDisplayName != "", "Dialogue alias " + name + " specifies a vdu bink without setting radioDisplayName as well." )
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 	if ( alias != "" && !DoesAliasExist( alias ) )
 	{
 		if ( alias.find( "%" ) >= 0 )
@@ -467,7 +467,7 @@ void function RegisterDialogueLine( string name, string alias, int priority, str
 		else
 			Warning( "Error: Dialogue '" + name + "': alias '" + alias + "' can't be registered because the alias does not exist" )
 	}
-#endif // SERVER && R5DEV
+#endif // SERVER && DEVELOPER
 
 	DialogueData data
 	data.alias = alias
@@ -503,7 +503,7 @@ void function RegisterDialogueLine( string name, string alias, int priority, str
 	s_prevNameRegistered = name
 }
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function VerifyExistenceOfNongenericAliases( string alias, string extraPerspective )
 {
 	array<string> specifiedPerspectiveAliases = []
@@ -545,7 +545,7 @@ void function IssueWarningIfAliasMissing( string alias )
 	if( !DoesAliasExist( alias ) )
 		Warning( "Error: Dialogue alias '" + alias + "' can't be registered because the alias does not exist. Most likely missing a Miles event." )
 }
-#endif // SERVER && R5DEV
+#endif // SERVER && DEVELOPER
 
 int function GetLinePriority( int aliasID )
 {
@@ -1392,7 +1392,7 @@ string function SpecifyAliasFromGeneric( DialogueData data, entity speaker )
 
 	if ( milesAlias.find( "%perspective%" ) >= 0 )
 	{
-		#if R5DEV
+		#if DEVELOPER
 			Assert( specifiedPerspective != "", "Dialogue with generic perspective specified in CSV alias without specifying intended perspective!" )
 		#endif //
 
@@ -1405,7 +1405,7 @@ string function SpecifyAliasFromGeneric( DialogueData data, entity speaker )
 	if ( milesAlias.find( "%voice%" ) >= 0 )
 		milesAlias = StringReplace( milesAlias, "%voice%", voice )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( ShouldTryToReplaceMissingVoiceWithTempVoice() )
 		{
 			if ( !DoesAliasExist( milesAlias ) )
@@ -1496,7 +1496,7 @@ void function SetUseDialogueVDU( bool useVDU )
 #endif //
 
 
-#if R5DEV
+#if DEVELOPER
 bool function ShouldTryToReplaceMissingVoiceWithTempVoice()
 {
 	return (GetCurrentPlaylistVarInt( "vo_fallback_to_temp", 0 ) == 1)

--- a/vscripts/sh_stats_internals.gnut
+++ b/vscripts/sh_stats_internals.gnut
@@ -45,7 +45,7 @@ global function StatsInternals_UpdatePersistenceOnDisconnect
 global function StatsInternals_UpdatePersistenceOnPurchase
 #endif
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 global function DEV_IncrementStat_Int // only global in dev for console commands (stats should never be incremented any where other than in this file)
 #endif
 
@@ -155,7 +155,7 @@ global struct StatEnumStruct
 
 	array<string> choices // the key choices for the tailing enum (e.g.: eWeaponFlavor -> r97, hemlok, alternator, ...)
 
-	#if R5DEV
+	#if DEVELOPER
 		string structName
 	#endif
 }
@@ -185,7 +185,7 @@ global struct StatTemplate
 #endif
 
 
-#if SERVER || CLIENT || UI && R5DEV
+#if SERVER || CLIENT || UI && DEVELOPER
 struct StatEnumStruct_Children
 {
 	array<StatEnumStruct> childEnumStructs
@@ -216,7 +216,7 @@ struct AdditionalStatsPlayerState
 struct FileStruct_LifetimeLevel
 {
 	#if SERVER || CLIENT || UI
-		#if R5DEV
+		#if DEVELOPER
 			StatEnumStruct_Children                        rootFieldsList // only for generating pdef file
 			table<StatEnumStruct, StatEnumStruct_Children> sesChildrenMap // hack
 		#endif
@@ -252,7 +252,7 @@ void function ShStatsInternals_LevelInit()
 	fileLevel = newFileLevel
 
 	#if SERVER
-		#if R5DEV
+		#if DEVELOPER
 			AddCallback_GeneratePDef( GenerateGameStatsPDef )
 			AddClientCommandCallback( "stats_dump", ClientCommand_stats_dump )
 			AddClientCommandCallback( "stats_set", ClientCommand_stats_set )
@@ -286,7 +286,7 @@ bool function GetStat_Bool( entity player, StatEntry entry, int when = eStatGetW
 	#if SERVER
 	return (when ? player.p.statValuesAtStart_Bool : player.p.statValues_Bool)[entry.indexWithinType]
 	#elseif CLIENT || UI
-		#if R5DEV
+		#if DEVELOPER
 			//if ( GetConVarBool( "persistence_development_mode", false ) )
 			if ( DEV_ShouldIgnorePersistence() )
 				return false
@@ -325,7 +325,7 @@ int function GetStat_Int( entity player, StatEntry entry, int when = eStatGetWhe
 	#if SERVER
 	return (when ? player.p.statValuesAtStart_Int : player.p.statValues_Int)[entry.indexWithinType]
 	#elseif CLIENT || UI 
-		#if R5DEV
+		#if DEVELOPER
 			///if ( GetConVarBool( "persistence_development_mode", false ) )
 			if ( DEV_ShouldIgnorePersistence() )
 				return 0
@@ -362,7 +362,7 @@ float function GetStat_Float( entity player, StatEntry entry, int when = eStatGe
 	#if SERVER
 		return (when ? player.p.statValuesAtStart_Float : player.p.statValues_Float)[entry.indexWithinType]
 	#elseif CLIENT || UI
-		#if R5DEV
+		#if DEVELOPER
 			//if ( GetConVarBool( "persistence_development_mode", false ) )
 			if ( DEV_ShouldIgnorePersistence() )
 				return 0
@@ -565,7 +565,7 @@ void function OnPersistentDataReady( entity player )
 	player.p.statValues_Float.resize( fileLevel.stats_Float.len(), 0.0 )
 	player.p.statValuesAtStart_Float.resize( fileLevel.stats_Float.len(), 0.0 )
 
-	#if R5DEV
+	#if DEVELOPER
 		//if ( GetConVarBool( "persistence_development_mode", false ) )
 		if ( DEV_ShouldIgnorePersistence() )
 			return
@@ -638,7 +638,7 @@ void function StatsInternals_UpdatePersistenceOnPurchase( entity player )
 ///////////////////////
 ///////////////////////
 
-#if SERVER || CLIENT || UI && R5DEV
+#if SERVER || CLIENT || UI && DEVELOPER
 string function DEV_GetStatTemplateDebugName( StatTemplate template )
 {
 	//string out = ""
@@ -654,7 +654,7 @@ string function DEV_GetStatTemplateDebugName( StatTemplate template )
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function DEV_IncrementStat_Int( entity player, StatEntry entry, int incrementAmount )
 {
 	__IncrementStat_Int( player, entry, incrementAmount )
@@ -662,7 +662,7 @@ void function DEV_IncrementStat_Int( entity player, StatEntry entry, int increme
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 bool function ClientCommand_stats_dump( entity player, array<string> args )
 {
 	printt( "--", "stats dump for", player )
@@ -681,7 +681,7 @@ bool function ClientCommand_stats_dump( entity player, array<string> args )
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 bool function ClientCommand_stats_set( entity player, array<string> args )
 {
 	string statRef = args[0]
@@ -961,7 +961,7 @@ StatEnumStruct function RegisterStatEnumStruct( StatEnumStruct ornull parentSESO
 	ses.enumName = enumName
 	ses.choices = choices
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( parentSESOrNull == null )
 		{
 			fileLevel.rootFieldsList.childEnumStructs.append( ses )
@@ -1027,7 +1027,7 @@ StatTemplate function InternalRegisterStatCommon( StatEnumStruct ornull parentSE
 			fileLevel.stats_Float.append( template.rootEntry )
 		}
 
-		#if R5DEV
+		#if DEVELOPER
 			fileLevel.rootFieldsList.childStatTemplates.append( template )
 		#endif
 
@@ -1037,7 +1037,7 @@ StatTemplate function InternalRegisterStatCommon( StatEnumStruct ornull parentSE
 	{
 		StatEnumStruct parentSES = expect StatEnumStruct(parentSESOrNull)
 
-		#if R5DEV
+		#if DEVELOPER
 			StatEnumStruct_Children sesChildren
 			if ( parentSES in fileLevel.sesChildrenMap )
 				sesChildren = fileLevel.sesChildrenMap[parentSES]
@@ -1224,7 +1224,7 @@ void function Stats_Save( entity player )
 {
 	Assert( player.IsPlayer() )
 
-	#if R5DEV
+	#if DEVELOPER
 		//if ( GetConVarBool( "persistence_development_mode", false ) )
 		if ( DEV_ShouldIgnorePersistence() )
 			return
@@ -1260,7 +1260,7 @@ void function Stats_Save( entity player )
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateGameStatsPDef()
 {
 	array<string> allWeaponStatsCategories = []
@@ -1296,7 +1296,7 @@ void function GenerateGameStatsPDef()
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateGameStatsPDef_RegisterSESRecursive( StatEnumStruct ses, StatEnumStruct ornull parentSESOrNull )
 {
 	if ( parentSESOrNull == null )
@@ -1332,7 +1332,7 @@ void function GenerateGameStatsPDef_RegisterSESRecursive( StatEnumStruct ses, St
 #endif
 
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateGameStatsPDef_AddStatField( StatTemplate stat )
 {
 	if ( stat.behavior == eStatBehavior.CALCULATED && !stat.shouldCache )

--- a/vscripts/sh_survival_deathfield.gnut
+++ b/vscripts/sh_survival_deathfield.gnut
@@ -3,7 +3,7 @@ global function GetDeathFieldStage
 global function GetDeathfieldFinalCenter
 global function SURVIVAL_GetDeathField
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 global function DEV_DrawCircleLocations
 global function DEV_SimulateFinalLocations
 global function DEV_ResetSurveyZones
@@ -350,7 +350,7 @@ void function SURVIVAL_AddCallback_OnDeathFieldStopShrink( void functionref( Dea
 
 void function DeathFieldCircleWait( float waitTime )
 {
-	#if R5DEV
+	#if DEVELOPER
 		svGlobal.levelEnt.EndSignal( "DeathField_ShrinkNow" )
 	#endif
 
@@ -360,7 +360,7 @@ void function DeathFieldCircleWait( float waitTime )
 
 void function DeathFieldShrinkThink( DeathFieldData data, entity deathField )
 {
-	#if R5DEV
+	#if DEVELOPER
 		svGlobal.levelEnt.EndSignal( "DeathField_ShrinkNow" )
 	#endif
 
@@ -517,7 +517,7 @@ void function SURVIVAL_RunArenaDeathField()
 			waitthread DeathFieldCircleWait( stage.preShrinkDuration )
 
 			// only change these settings if we dev-skipped the previous circle since it will send an unwated message
-			#if R5DEV
+			#if DEVELOPER
 				if ( fabs( Time() + MARGIN_WAIT_TIME - data.startTime ) > 1.0 )
 				{
 					printt( "reset net time" )
@@ -582,7 +582,7 @@ void function SURVIVAL_RunArenaDeathField()
 		data.center = mover.GetOrigin()
 
 		// only change these settings if we dev-skipped the previous circle since it will send an unwated message
-		#if R5DEV
+		#if DEVELOPER
 			if ( Time() < GetGlobalNetTime( "nextCircleStartTime" ) + MARGIN_WAIT_TIME + stage.shrinkDuration - 1.0 )
 			{
 				SetGlobalNetTime( "nextCircleStartTime", Time() - (stage.shrinkDuration + stage.preShrinkDuration) )
@@ -760,7 +760,7 @@ bool function ClientCommand_UpdateCirclePos( entity player, array<string> args )
 	float argY    = float( args[1] )
 	vector newPos = <argX, argY, 0>
 
-	#if R5DEV
+	#if DEVELOPER
 		thread DEV_ForceDeathFieldPosition( newPos )
 		return true
 	#endif
@@ -768,7 +768,7 @@ bool function ClientCommand_UpdateCirclePos( entity player, array<string> args )
 	return false
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_ForceDeathFieldPosition( vector endPos )
 {
 	if ( !SURVIVAL_IsValidCircleLocation( endPos ) )
@@ -818,7 +818,7 @@ void function DEV_ResetSurveyZones()
 
 void function SURVIVAL_AddOverrideCircleLocation( vector origin, float radius )
 {
-	#if R5DEV
+	#if DEVELOPER
 		file.overrideCircleEndPos[ origin ] <- radius
 	#endif
 }

--- a/vscripts/sh_survival_deathfield.gnut
+++ b/vscripts/sh_survival_deathfield.gnut
@@ -406,7 +406,7 @@ void function SURVIVAL_RunArenaDeathField()
 	vector lastCenter   = file.deathFieldStages[file.deathFieldStartStage].endPos
 	
 	if(GetCurrentPlaylistVarBool( "dummies_horde_enabled", false ))
-		lastCenter   = <gp()[0].GetOrigin().x, gp()[0].GetOrigin().y, 0>
+		lastCenter   = <GetPlayerArray()[0].GetOrigin().x, GetPlayerArray()[0].GetOrigin().y, 0>
 	
 	data.center = lastCenter
 	data.nextCenter = lastCenter

--- a/vscripts/sh_survival_freefall.gnut
+++ b/vscripts/sh_survival_freefall.gnut
@@ -608,7 +608,7 @@ void function SkyDiveMovement( entity player, SkydivePlayerData skydiveData, vec
 	if ( jumpingFromPlane )
 	{
 		entity planeEnt = Sur_GetPlaneEnt()
-		#if !R5DEV
+		#if !DEVELOPER
 			Assert( IsValid( planeEnt ), "Tried to skydive but there is no plane entity" )
 		#endif
 		if ( IsValid( planeEnt ) )
@@ -712,7 +712,7 @@ void function SkyDiveMovement( entity player, SkydivePlayerData skydiveData, vec
 
 	float currentYaw = player.GetAngles().y
 
-	#if R5DEV
+	#if DEVELOPER
 		float botLastForwardInputTime = 0.0
 		float botNextForwardInputTime = 0.0
 		float botLastForwardInput = 0.0
@@ -759,7 +759,7 @@ void function SkyDiveMovement( entity player, SkydivePlayerData skydiveData, vec
 			}
 		}
 
-		#if R5DEV
+		#if DEVELOPER
 		// Bots fly random paths, turning, speeding up and slowing down
 		if ( player == leaderPlayer && player.IsBot() )
 		{

--- a/vscripts/sh_survival_loot.gnut
+++ b/vscripts/sh_survival_loot.gnut
@@ -90,7 +90,7 @@ global function Dev_SpawnAllLootTypes
 global function SURVIVAL_Loot_GetByType_InLevel
 global function SURVIVAL_Loot_DisableNetworkDistanceCullingManaged
 global function SURVIVAL_Loot_EnableNetworkDistanceCullingManaged
-#if R5DEV
+#if DEVELOPER
 global function Dev_GetNextBotLootWeapon
 global function Dev_SpawnBotWithIncapShieldToView
 #endif
@@ -2771,7 +2771,7 @@ void function Dev_SpawnAllLootTypes( vector startPos, vector diffPosCol, vector 
 }
 #endif // SERVER
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 int Dev_botWeaponIndex = -1
 string function Dev_GetNextBotLootWeapon()
 {

--- a/vscripts/sh_survival_loot_actions.gnut
+++ b/vscripts/sh_survival_loot_actions.gnut
@@ -334,7 +334,7 @@ bool function PickupAmmo( entity ammoPickup, entity player, int pickupFlags = 0,
 	numToPickup = minint( numToPickup, poolMax - poolCount )
 
 #if SERVER
-#if R5DEV
+#if DEVELOPER
 	//if ( !GetConVarBool( "sv_infinite_ammo" ) ) // Cvar does not exist in retail engine
 #endif
 	player.AmmoPool_SetCount( ammoType, poolCount + numToPickup )

--- a/vscripts/sh_survival_loot_all.gnut
+++ b/vscripts/sh_survival_loot_all.gnut
@@ -17,7 +17,7 @@ global function GetCustomHopupArray
 global function GetRarityColor
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 global function DumpModdedKeyColors
 global function DiffKeyColors
 #endif
@@ -1074,7 +1074,7 @@ vector function GetFXRarityColorForUnlockable( int tier )
 	unreachable
 }
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DumpModdedKeyColors( int colorID, float modVal )
 {
 	for ( int index = 0; index < 6; index++ )
@@ -1089,7 +1089,7 @@ void function DumpModdedKeyColors( int colorID, float modVal )
 }
 #endif
 
-#if CLIENT && R5DEV
+#if CLIENT && DEVELOPER
 void function DiffKeyColors( int baseColorID, int colorID )
 {
 	var datatable = GetDataTable( $"datatable/colorpalette_table.rpak" )

--- a/vscripts/sh_utility_all.gnut
+++ b/vscripts/sh_utility_all.gnut
@@ -2392,7 +2392,7 @@ entity function AssertLocalOrServerValidPlayer( entity player )
 
 bool function IsEverythingUnlocked()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( GetCurrentPlaylistVarBool( "dev_force_everything_unlocked", false ) )
 			return true
 	#endif

--- a/vscripts/sh_weapon_cosmetics.nut
+++ b/vscripts/sh_weapon_cosmetics.nut
@@ -27,7 +27,7 @@ global function AddCallback_UpdatePlayerWeaponCosmetics
 global function WeaponSkin_Apply
 global function WeaponCosmetics_Apply
 #endif
-#if R5DEV && CLIENT
+#if DEVELOPER && CLIENT
 global function DEV_TestWeaponSkinData
 global function DEV_GetCharmForCurrentWeapon
 global function DEV_SetCharmForCurrentWeapon
@@ -132,7 +132,7 @@ void function OnItemFlavorRegistered_LootMainWeapon( ItemFlavor weaponFlavor )
 			return !IsLobby()
 		}
 		entry.networkTo = eLoadoutNetworking.PLAYER_EXCLUSIVE
-		#if SERVER && R5DEV
+		#if SERVER && DEVELOPER
 			entry.isCurrentlyRelevant = bool function( EHI playerEHI ) : ( weaponFlavor ) {
 				entity player          = FromEHI( playerEHI )
 				string weaponClassName = WeaponItemFlavor_GetClassname( weaponFlavor )
@@ -320,7 +320,7 @@ int function WeaponSkin_GetSortOrdinal( ItemFlavor flavor )
 	return fileLevel.cosmeticFlavorSortOrdinalMap[flavor]
 }
 
-#if R5DEV && CLIENT 
+#if DEVELOPER && CLIENT 
 void function DEV_SetCharmForCurrentWeapon( asset charmModel, string attachmentName )
 {
 	entity player = GetLocalClientPlayer()
@@ -416,7 +416,7 @@ void function WeaponSkin_Apply( entity ent, ItemFlavor skin )
 #if SERVER
 void function UpdatePlayerWeaponCosmetics( entity player, ItemFlavor weaponFlavor, ItemFlavor skin )
 {
-	#if R5DEV
+	#if DEVELOPER
 		string weaponClassName = WeaponItemFlavor_GetClassname( weaponFlavor )
 
 		foreach( entity weapon in player.GetMainWeapons() )
@@ -766,7 +766,7 @@ void function DestroyCharmForWeaponEntity( entity weapEnt )
 #endif
 
 
-#if R5DEV && CLIENT
+#if DEVELOPER && CLIENT
 void function DEV_TestWeaponSkinData()
 {
 	entity model = CreateClientSidePropDynamic( <0, 0, 0>, <0, 0, 0>, $"mdl/dev/empty_model.rmdl" )
@@ -784,4 +784,4 @@ void function DEV_TestWeaponSkinData()
 
 	model.Destroy()
 }
-#endif // DEV && CLIENT
+#endif // DEVELOPER && CLIENT

--- a/vscripts/sh_weapons.gnut
+++ b/vscripts/sh_weapons.gnut
@@ -57,11 +57,11 @@ void function ShWeapons_LevelInit()
 	FileStruct_LifetimeLevel newFileLevel
 	fileLevel = newFileLevel
 
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 		AddCallback_GeneratePDef( GenerateWeaponsPDef )
 	#endif
 
-	#if (SERVER || CLIENT) //&& R5DEV // (dw): needs to be precached even in non-DEV to support DEV clients connecting to non-DEV servers
+	#if (SERVER || CLIENT) //&& DEVELOPER // (dw): needs to be precached even in non-DEV to support DEV clients connecting to non-DEV servers
 		PrecacheWeapon( $"weapon_cubemap" )
 	#endif
 
@@ -274,7 +274,7 @@ void function ShowDefaultBodygroupsOnFakeWeapon( entity ent, string weaponClassN
 //// Internals ////
 ///////////////////
 ///////////////////
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function GenerateWeaponsPDef()
 {
 	// this persistent data enum is required by sh_xp.gnut

--- a/vscripts/sh_xp.gnut
+++ b/vscripts/sh_xp.gnut
@@ -33,7 +33,7 @@ global function GetNextAccountLevel
 #if SERVER
 global function InitXP
 global function XP_GameStartedPlaying
-#if R5DEV
+#if DEVELOPER
 global function DEV_PopulatePostGame
 #endif //DEV
 #else
@@ -147,7 +147,7 @@ int function GetPlayerAccountXPProgress( EHI playerEHI )
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence_Local() )
 			return 0
 	#endif
@@ -161,7 +161,7 @@ int function GetPlayerAccountXPPreviousProgress( EHI playerEHI )
 		Assert( playerEHI == LocalClientEHI() )
 	#endif
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence_Local() )
 			return 0
 	#endif
@@ -199,7 +199,7 @@ void function InitXP( entity player )
 
 void function XP_GameStartedPlaying()
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEV_ShouldIgnorePersistence_Local() )
 			return
 	#endif
@@ -335,7 +335,7 @@ var function CreateNestedAccountDisplayBadge( var parentRui, string arg, int lev
 }
 #endif //UI
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 void function AddXP( entity player, int xpType, ... )
 {
 	//

--- a/vscripts/superbar/smokescreen.nut
+++ b/vscripts/superbar/smokescreen.nut
@@ -5,7 +5,7 @@ global function IsOriginTouchingSmokescreen
 global function IsRayTouchingSmokescreen
 global function GetFXCenterFromSmokescreen
 
-#if R5DEV
+#if DEVELOPER
 const bool SMOKESCREEN_DEBUG = false
 #endif
 
@@ -111,7 +111,7 @@ void function Smokescreen( SmokescreenStruct smokescreen, entity player )
 	if ( smokescreen.blockLOS )
 		traceBlocker = Smokescreen_CreateTraceBlockerVol( smokescreen, fxInfo )
 
-#if R5DEV
+#if DEVELOPER
 	if ( SMOKESCREEN_DEBUG )
 		DebugDrawCircle( fxInfo.center, <0,0,0>, fxInfo.radius + 240.0, 255, 255, 0, true, smokescreen.lifetime )
 #endif
@@ -225,7 +225,7 @@ void function SmokescreenAffectsEntitiesInArea( SmokescreenStruct smokescreen, S
 
 	while ( Time() - startTime <= smokescreen.lifetime )
 	{
-#if R5DEV
+#if DEVELOPER
 		if ( SMOKESCREEN_DEBUG )
 		{
 			DebugDrawCircle( fxInfo.center, <0,0,0>, smokescreen.damageInnerRadius, 255, 0, 0, true, tickRate )
@@ -260,7 +260,7 @@ entity function Smokescreen_CreateTraceBlockerVol( SmokescreenStruct smokescreen
 	DispatchSpawn( traceBlockerVol )
 	traceBlockerVol.SetBox( fxInfo.mins * 0.9, fxInfo.maxs * 0.9 )
 
-#if R5DEV
+#if DEVELOPER
 	if ( SMOKESCREEN_DEBUG )
 		DrawAngledBox( fxInfo.center, smokescreen.angles, fxInfo.mins, fxInfo.maxs, 255, 0, 0, true, smokescreen.lifetime - 0.6 )
 #endif
@@ -274,7 +274,7 @@ array<entity> function SmokescreenFX( SmokescreenStruct smokescreen, Smokescreen
 
 	foreach ( position in fxInfo.fxWorldPositions )
 	{
-#if R5DEV
+#if DEVELOPER
 		if ( SMOKESCREEN_DEBUG )
 			DebugDrawCircle( position, <0.0, 0.0, 0.0>, smokescreen.fxXYRadius, 0, 0, 255, true, smokescreen.lifetime )
 #endif

--- a/vscripts/survival_ship.gnut
+++ b/vscripts/survival_ship.gnut
@@ -11,7 +11,7 @@ global function SURVIVAL_SetPlaneHeight
 global function SURVIVAL_SetAirburstHeight
 global function SURVIVAL_SetMapCenter
 global function SURVIVAL_SetMapDelta
-#if R5DEV
+#if DEVELOPER
 global function GetDropshipClearance
 #endif
 

--- a/vscripts/titan/cl_titan_soul.gnut
+++ b/vscripts/titan/cl_titan_soul.gnut
@@ -149,7 +149,7 @@ void function FirstPersonEnded_UpdateTitanHealthFX( entity spectatingPlayer, ent
 	if ( !IsValid( titanSoul ) )
 		return
 
-	#if R5DEV
+	#if DEVELOPER
 	if ( !ModelHasFXGroup( spectatorTarget.GetModelName() ) )
 		return
 	#endif

--- a/vscripts/titan/sh_titan_embark.gnut
+++ b/vscripts/titan/sh_titan_embark.gnut
@@ -37,7 +37,7 @@ global function IsPlayerDisembarking
 	//global function ClientCommand_TitanDisembark
 #endif
 
-#if R5DEV
+#if DEVELOPER
 	global function SetEmbarkDebugPrint
 #endif
 
@@ -720,7 +720,7 @@ void function TitanEmbarkFailsafe( entity player, entity titan, entity groundEnt
 	if ( GetCurrentPlaylistVarInt( "player_embark_in_solid_checks", 1 ) != 1 )
 		return
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.embarkDebugPrint )
 		{
 			if ( IsValid( titan ) )
@@ -733,7 +733,7 @@ void function TitanEmbarkFailsafe( entity player, entity titan, entity groundEnt
 	if ( !PutEntityInSafeSpot( player, titan, groundEnt, startOrigin, player.GetOrigin() ) )
 		player.SetOrigin( startOrigin )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.embarkDebugPrint )
 		{
 			if ( IsValid( titan ) )
@@ -1353,7 +1353,7 @@ void function TitanEmbark_TitanEmbarks( entity player, entity titan, table e )
 //			     TraceLineSimple( titanOrigin + <0,0,200>, clampedPos + <0,0,0>, titan ) == 1.0 ||
 //			     TraceLineSimple( titanOrigin + <0,0,200>, clampedPos + <0,0,128>, titan ) == 1.0 )
 //			{
-//				#if R5DEV
+//				#if DEVELOPER
 //					if ( file.embarkDebugPrint )
 //					{
 //						printt( "PlayerDisembarksTitanWithSequenceFuncs, player origin: " + player.GetOrigin()+ ", titan origin: " + titan.GetOrigin() + ", clampedPos: " + clampedPos )
@@ -1366,7 +1366,7 @@ void function TitanEmbark_TitanEmbarks( entity player, entity titan, table e )
 //	}
 //	else
 //	{
-//		#if R5DEV
+//		#if DEVELOPER
 //			if ( file.embarkDebugPrint )
 //			{
 //				printt( "PlayerIsFarOffGround() returned true, skip doing NavMesh_ClampPointForAIWithExtents checks" )
@@ -1561,7 +1561,7 @@ void function DelayedSafePlayerLocationForDisembark( entity player, entity titan
 		safeStartPoint = player.GetOrigin()
 	}
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.embarkDebugPrint )
 			printt( "DelayedSafePlayerLocationForDisembark, before PutEntityInSafeSpot: player origin: " + player.GetOrigin() + ", titan origin: " + titan.GetOrigin() + " safeStartPoint: " + safeStartPoint )
 	#endif
@@ -1571,7 +1571,7 @@ void function DelayedSafePlayerLocationForDisembark( entity player, entity titan
 	if ( !PutEntityInSafeSpot( player, titan, null, safeStartPoint, player.GetOrigin() ) )
 		player.SetOrigin( safeStartPoint )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( file.embarkDebugPrint )
 			printt( "DelayedSafePlayerLocationForDisembark, after PutEntityInSafeSpot: player origin: " + player.GetOrigin() + ", titan origin: " + titan.GetOrigin() + " safeStartPoint: " + safeStartPoint )
 	#endif
@@ -2105,12 +2105,12 @@ void function SetLargeDisembarkFailSafeTeleportVector( vector value ) //TODO: Re
 }
 #endif // SERVER
 
-#if R5DEV
+#if DEVELOPER
 void function SetEmbarkDebugPrint( bool value )
 {
 	file.embarkDebugPrint = value
 }
-#endif // DEV
+#endif // DEVELOPER
 
 bool function PlayerHasFastEmbark( entity player )
 {

--- a/vscripts/ui/_menus.nut
+++ b/vscripts/ui/_menus.nut
@@ -148,9 +148,9 @@ global function OpenXboxPartyApp
 global function OpenXboxHelp
 #endif //DURANGO_PROG
 
-#if R5DEV
+#if DEVELOPER
 global function OpenDevMenu
-#endif // R5DEV
+#endif // DEVELOPER
 
 global function OpenModelMenu
 
@@ -499,7 +499,7 @@ void function UICodeCallback_FullyConnected( string levelname )
 
 	InitXPData()
 
-	#if R5DEV
+	#if DEVELOPER
 		ShDevUtility_Init()
 	#endif
 
@@ -553,7 +553,7 @@ void function UICodeCallback_FullyConnected( string levelname )
 	//ShWeaponXP_Init()
 	//ShFactionXP_Init()
 
-	#if R5DEV
+	#if DEVELOPER
 		UpdatePrecachedSPWeapons()
 	#endif
 
@@ -2536,12 +2536,12 @@ void function OpenXboxHelp( var button )
 }
 #endif // DURANGO_PROG
 
-#if R5DEV
+#if DEVELOPER
 void function OpenDevMenu( var button )
 {
 	AdvanceMenu( GetMenu( "DevMenu" ) )
 }
-#endif //R5DEV
+#endif // DEVELOPER
 
 void function OpenModelMenu (string equipped) {
 	

--- a/vscripts/ui/_promo_data.nut
+++ b/vscripts/ui/_promo_data.nut
@@ -10,7 +10,7 @@ global function GetMiniPromoRpakName
 
 global function UICodeCallback_MainMenuPromosUpdated
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_PrintPromoData
 #endif //
 
@@ -51,7 +51,7 @@ void function InitPromoData()
 
 void function UpdatePromoData()
 {
-	#if R5DEV
+	#if DEVELOPER
 		//if ( GetConVarBool( "mainMenuPromos_scriptUpdateDisabled" ) || GetCurrentPlaylistVarBool( "mainMenuPromos_scriptUpdateDisabled", false ) )
 		//	return
 	#endif //
@@ -63,7 +63,7 @@ void function UICodeCallback_MainMenuPromosUpdated()
 {
 	printt( "Promos updated" )
 
-	#if R5DEV
+	#if DEVELOPER
 		//if ( GetConVarInt( "mainMenuPromos_preview" ) == 1 ) // ConVar is not registered in R5Launch
 			//UpdatePromoData()
 	#endif //
@@ -101,7 +101,7 @@ asset function GetPromoImage( string identifier )
 	return image
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_PrintPromoData()
 {
 	printt( "protocol:      ", file.promoData.prot )

--- a/vscripts/ui/_surveys.nut
+++ b/vscripts/ui/_surveys.nut
@@ -57,7 +57,7 @@ void function OpenSurveyByRef( string surveyRef, float sampleRate )
 	{
 		string answerText = result == eDialogResult.YES ? aAnswerText : bAnswerText
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( !("mid" in uiGlobal.matchPinData) )
 			{
 				uiGlobal.matchPinData["mid"] <- "[fe80::78dc:e7ef:e13b:68e]:0:37015:1562712876"

--- a/vscripts/ui/combo_buttons.nut
+++ b/vscripts/ui/combo_buttons.nut
@@ -16,7 +16,7 @@ global function SetComboButtonHeaderTint
 
 global function ComboButtons_ResetColumnFocus
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_GetComboStruct
 #endif
 
@@ -387,7 +387,7 @@ var function AddComboButton( ComboStruct comboStruct, int rowIndex, int colIndex
 	return button
 }
 
-#if R5DEV
+#if DEVELOPER
 ComboStruct function DEV_GetComboStruct( string menuName )
 {
 	ComboStruct comboStruct = file.comboMenuData[menuName]

--- a/vscripts/ui/customize_common.gnut
+++ b/vscripts/ui/customize_common.gnut
@@ -169,7 +169,7 @@ void function CustomizeButton_UpdateAndMarkForUpdating( var button,
 		)
 {
 	Assert( !(button in fileLevel.activeCustomizeButtons) )
-	#if R5DEV
+	#if DEVELOPER
 		foreach ( var buttonIter, CustomizeButtonContext cbcIter in fileLevel.activeCustomizeButtons )
 		{
 			Assert( Hud_GetParent( button ) == Hud_GetParent( buttonIter ), "Customize buttons from different parents were active at the same time!" )

--- a/vscripts/ui/dialogs/low_pop.nut
+++ b/vscripts/ui/dialogs/low_pop.nut
@@ -13,7 +13,7 @@ global function LowPop_SetRankedDatacenter
 
 global function ToRelativeTimeString
 
-#if R5DEV
+#if DEVELOPER
 global function DisplayLowPopWarning
 
 const bool DEBUG_LOW_POP = false
@@ -29,7 +29,7 @@ struct
 	void functionref(int) onButtonClickCallback
 	table<var, MatchmakingDatacenterETA> buttonToDatacenter
 
-#if R5DEV
+#if DEVELOPER
 	array<MatchmakingDatacenterETA> fakeDatacenters
 	int fakeHomeDatacenter = 0
 	int fakeRankedDatacenter = 0
@@ -64,7 +64,7 @@ void function InitLowPopDialog( var newMenuArg ) //
 	AddMenuEventHandler( menu, eUIEvent.MENU_OPEN, OnLowPopMenuOpen )
 	AddMenuEventHandler( menu, eUIEvent.MENU_CLOSE, OnLowPopMenuClose )
 
-	#if R5DEV
+	#if DEVELOPER
 	GenerateFakeDatacenter( "australia", 150 , 300 )
 	GenerateFakeDatacenter( "japan", 150 , 100 )
 	GenerateFakeDatacenter( "west us", 200 , 50 )
@@ -73,7 +73,7 @@ void function InitLowPopDialog( var newMenuArg ) //
 	#endif
 }
 
-#if R5DEV
+#if DEVELOPER
 void function GenerateFakeDatacenter( string name, int latency, int etaSeconds )
 {
 	MatchmakingDatacenterETA fakeData
@@ -195,7 +195,7 @@ array<MatchmakingDatacenterETA> function GetValidMatchmakingDatacenterETASorted(
 {
 	array< MatchmakingDatacenterETA > datas = GetMatchmakingDatacenterETAs( playlistName )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEBUG_LOW_POP )
 		{
 			datas = clone file.fakeDatacenters
@@ -233,7 +233,7 @@ array<MatchmakingDatacenterETA> function GetValidMatchmakingDatacenterETASorted(
 
 MatchmakingDatacenterETA function GetCurrentRankedMatchmakingDatacenterETA( string playlistName )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEBUG_LOW_POP )
 		{
 			return file.fakeDatacenters[ file.fakeRankedDatacenter ]
@@ -249,7 +249,7 @@ MatchmakingDatacenterETA function GetCurrentRankedMatchmakingDatacenterETA( stri
 
 MatchmakingDatacenterETA function GetCurrentMatchmakingDatacenterETA( string playlistName )
 {
-	#if R5DEV
+	#if DEVELOPER
 		if ( DEBUG_LOW_POP )
 		{
 			return file.fakeDatacenters[ file.fakeHomeDatacenter ]
@@ -441,7 +441,7 @@ string function ToRelativeTimeString( int timestamp, int minsCap = 0 )
 void function LowPop_SetRankedDatacenter( int datacenterIdx )
 {
 	SetRankedDatacenter( datacenterIdx )
-	#if R5DEV
+	#if DEVELOPER
 		file.fakeRankedDatacenter = datacenterIdx
 	#endif
 }

--- a/vscripts/ui/image_pak_load.nut
+++ b/vscripts/ui/image_pak_load.nut
@@ -10,7 +10,7 @@ global function GetDownloadedImageAsset
 global function UISetRpakLoadStatus
 #endif
 
-#if R5DEV && CLIENT 
+#if DEVELOPER && CLIENT 
 global function DEV_CopyRpakLoadStatuses
 #endif
 
@@ -64,7 +64,7 @@ void function ClImagePakLoadInit()
 {
 	RegisterSignal( "RequestDownloadedImagePakLoad" )
 
-#if R5DEV
+#if DEVELOPER
 	AddCallback_UIScriptReset( DEV_CopyRpakLoadStatuses )
 #endif
 }
@@ -143,7 +143,7 @@ void function SetRpakLoadStatus( string rpakName, int status )
 }
 #endif
 
-#if R5DEV && CLIENT 
+#if DEVELOPER && CLIENT 
 void function DEV_CopyRpakLoadStatuses()
 {
 	//

--- a/vscripts/ui/lobby_panel_play.nut
+++ b/vscripts/ui/lobby_panel_play.nut
@@ -32,7 +32,7 @@ global function ShouldShowLastGameRankedAbandonForgivenessDialog
 global function ShowLastGameRankedAbandonForgivenessDialog
 global function PulseModeButton
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_PrintPartyInfo
 global function DEV_PrintUserInfo
 global function Lobby_MovePopupMessage
@@ -1821,7 +1821,7 @@ var function GetPartyMemberButton( string uid )
 	return null
 }
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_PrintPartyInfo()
 {
 	Party party = GetParty()

--- a/vscripts/ui/lobby_panel_store.nut
+++ b/vscripts/ui/lobby_panel_store.nut
@@ -12,7 +12,7 @@ global function JumpToStoreCharacter
 global function JumpToStoreSkin
 global function JumpToThemedShop
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_OffersPanel_DoFakeOffers
 #endif
 
@@ -41,7 +41,7 @@ struct
 	var  tabBar
 	bool openDLCStoreCallbackCalled = false
 
-	#if R5DEV
+	#if DEVELOPER
 		string DEV_fakeOffers_itemRef      = ""
 		string DEV_fakeOffers_seasonTag    = ""
 		int[5] DEV_fakeOffers_columnCounts = [1, 1, 1, 1, 1]
@@ -1188,7 +1188,7 @@ void function InitOffers()
 	{
 		array<GRXScriptOffer> columnOffers = GRX_GetStoreOfferColumn( col )
 
-		#if R5DEV
+		#if DEVELOPER
 			if ( file.DEV_fakeOffers_itemRef != "" )
 			{
 				array<GRXScriptOffer> fakeOffers
@@ -1376,7 +1376,7 @@ void function ClearOffers()
 }
 
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_OffersPanel_DoFakeOffers( bool doIt = false, string itemRef = "character_skin_caustic_legendary_04", string seasonTag = "", int col0 = 2, int col1 = 1, int col2 = 1, int col3 = 1, int col4 = 1 )
 {
 	if ( !doIt )

--- a/vscripts/ui/menu_dev.nut
+++ b/vscripts/ui/menu_dev.nut
@@ -1,7 +1,7 @@
 untyped
 
 global function InitDevMenu
-#if R5DEV
+#if DEVELOPER
 global function DEV_InitLoadoutDevSubMenu
 global function SetupDevCommand // for dev
 global function SetupDevFunc // for dev
@@ -72,7 +72,7 @@ function Dummy_Untyped( param )
 
 void function InitDevMenu( var newMenuArg )
 {
-	#if R5DEV
+	#if DEVELOPER
 		var menu = GetMenu( "DevMenu" )
 
 		AddMenuEventHandler( menu, eUIEvent.MENU_OPEN, OnOpenDevMenu )
@@ -105,7 +105,7 @@ void function InitDevMenu( var newMenuArg )
 
 void function AddLevelDevCommand( string label, string command )
 {
-	#if R5DEV
+	#if DEVELOPER
 		string codeDevMenuAlias = DEV_MENU_NAME + "/" + label
 		DevMenu_Alias_DEV( codeDevMenuAlias, command )
 
@@ -116,7 +116,7 @@ void function AddLevelDevCommand( string label, string command )
 	#endif
 }
 
-#if R5DEV
+#if DEVELOPER
 void function OnOpenDevMenu()
 {
 	file.pageHistory.clear()

--- a/vscripts/ui/menu_elite_intro.nut
+++ b/vscripts/ui/menu_elite_intro.nut
@@ -2,7 +2,7 @@ global function InitEliteIntroMenu
 global function OpenEliteIntroMenu
 global function OpenEliteIntroMenuNonAnimated
 
-#if R5DEV
+#if DEVELOPER
 global function TestEliteIntroMenu
 #endif
 

--- a/vscripts/ui/menu_eog_squad_summary.nut
+++ b/vscripts/ui/menu_eog_squad_summary.nut
@@ -127,7 +127,7 @@ void function InitEOGMenu( var newMenuArg ) //
 	AddMenuFooterOption( menu, LEFT, KEY_TAB, false, "", "", Spectate )
 	AddMenuFooterOption( menu, LEFT, BUTTON_A, false, "", "", TrySpectate )
 
-	#if R5DEV
+	#if DEVELOPER
 		AddMenuFooterOption( menu, LEFT, BUTTON_Y, true, "Dev Menu", "Dev Menu", OpenDevMenu )
 	#endif
 

--- a/vscripts/ui/menu_ingame.nut
+++ b/vscripts/ui/menu_ingame.nut
@@ -80,7 +80,7 @@ void function InitInGameMPMenu( var newMenuArg )
 	var gameHeader = AddComboButtonHeader( comboStruct, headerIndex, "#MENU_HEADER_GAME" )
 	var leaveButton = AddComboButton( comboStruct, headerIndex, buttonIndex++, "#LEAVE_MATCH" )
 	Hud_AddEventHandler( leaveButton, UIE_CLICK, OnLeaveButton_Activate )
-	#if R5DEV
+	#if DEVELOPER
 		var devButton = AddComboButton( comboStruct, headerIndex, buttonIndex++, "Dev" )
 		Hud_AddEventHandler( devButton, UIE_CLICK, AdvanceMenuEventHandler( GetMenu( "DevMenu" ) ) )
 	#endif

--- a/vscripts/ui/menu_post_game_battlepass.nut
+++ b/vscripts/ui/menu_post_game_battlepass.nut
@@ -63,7 +63,7 @@ void function OpenPostGameBattlePassMenu( bool firstTime )
 {
 	bool forceFirstTime = false
 
-	#if R5DEV
+	#if DEVELOPER
 		forceFirstTime = GetBugReproNum() == 100
 	#endif
 

--- a/vscripts/ui/menu_ranked_info.nut
+++ b/vscripts/ui/menu_ranked_info.nut
@@ -3,7 +3,7 @@ global function OpenRankedInfoPage
 global function InitRankedScoreBarRui
 global function InitRankedScoreBarRuiForDoubleBadge
 
-#if R5DEV
+#if DEVELOPER
 global function TestScoreBar
 #endif
 

--- a/vscripts/ui/menu_reward_ceremony.nut
+++ b/vscripts/ui/menu_reward_ceremony.nut
@@ -3,7 +3,7 @@
 global function InitRewardCeremonyMenu
 global function ShowRewardCeremonyDialog
 
-#if R5DEV
+#if DEVELOPER
 global function DEV_TestRewardCeremonyDialog
 #endif
 
@@ -66,7 +66,7 @@ void function ShowRewardCeremonyDialog( string headerText, string titleText, str
 }
 
 
-#if R5DEV
+#if DEVELOPER
 void function DEV_TestRewardCeremonyDialog( string itemRef, string headerText = "HEADER", string titleText = "TITLE", string descText = "DESC" )
 {
 	BattlePassReward rewardInfo

--- a/vscripts/ui/menu_social.nut
+++ b/vscripts/ui/menu_social.nut
@@ -938,7 +938,7 @@ void function PreviewFriendCosmetics( bool isForLocalPlayer, CommunityUserInfo o
 	else
 	{
 		CommunityUserInfo userInfo = expect CommunityUserInfo(userInfoOrNull)
-		#if R5DEV
+		#if DEVELOPER
 			DEV_PrintUserInfo( userInfo )
 		#endif
 

--- a/vscripts/ui/menu_system.nut
+++ b/vscripts/ui/menu_system.nut
@@ -51,7 +51,7 @@ void function InitSystemPanelMain( var panel )
 	InitSystemPanel( panel )
 
 	AddPanelFooterOption( panel, LEFT, BUTTON_B, true, "#B_BUTTON_BACK", "#B_BUTTON_BACK" )
-	#if R5DEV
+	#if DEVELOPER
 	if ( Dev_CommandLineHasParm( "-showdevmenu" ) )
 		AddPanelFooterOption( panel, LEFT, BUTTON_Y, true, "#Y_BUTTON_DEV_MENU", "#DEV_MENU", OpenDevMenu, ShouldShowDevMenu )
 	#endif

--- a/vscripts/ui/panel_mainmenu.nut
+++ b/vscripts/ui/panel_mainmenu.nut
@@ -121,7 +121,7 @@ bool function IsDataCenterFooterVisible()
 
 bool function IsDataCenterFooterClickable()
 {
-#if R5DEV
+#if DEVELOPER
 	bool hideDurationElapsed = true
 #else //
 	bool hideDurationElapsed = Time() - file.startTime > 10.0
@@ -208,14 +208,14 @@ void function PrelaunchValidation( bool autoContinue = false )
 		PrintLaunchDebugVal( "isOriginEnabled", isOriginEnabled )
 		if ( !isOriginEnabled )
 		{
-			#if R5DEV
+			#if DEVELOPER
 				if ( autoContinue )
 					LaunchMP()
 				else
 					SetLaunchState( eLaunchState.WAIT_TO_CONTINUE, "", Localize( "#MAINMENU_CONTINUE" ) )
 
 				return
-			#endif // DEV
+			#endif // DEVELOPER
 
 			SetLaunchState( eLaunchState.WAIT_TO_CONTINUE, Localize( "#ORIGIN_IS_OFFLINE" ), Localize( "#MAINMENU_RETRY" ) )
 			return
@@ -886,9 +886,9 @@ void function OnConfirmDialogResult( int result )
 
 void function PrintLaunchDebugVal( string name, bool val )
 {
-	#if R5DEV
+	#if DEVELOPER
 		printt( "*** PrelaunchValidation *** " + name + ": " + val )
-	#endif // DEV
+	#endif // DEVELOPER
 }
 
 

--- a/vscripts/ui/panel_survival_quick_inventory_v2.nut
+++ b/vscripts/ui/panel_survival_quick_inventory_v2.nut
@@ -205,7 +205,7 @@ void function InitInventoryFooter( var panel )
 	AddPanelFooterOption( panel, LEFT, BUTTON_B, true, "#B_BUTTON_BACK", "#B_BUTTON_BACK" )
 	AddPanelFooterOption( panel, RIGHT, BUTTON_START, true, "#HINT_SYSTEM_MENU_GAMEPAD", "#HINT_SYSTEM_MENU_KB", TryOpenSystemMenu )
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( Dev_CommandLineHasParm( "-showdevmenu" ) )
 			AddPanelFooterOption( panel, LEFT, BUTTON_STICK_LEFT, true, "#LEFT_STICK_DEV_MENU", "#DEV_MENU", OpenDevMenu )
 	#endif

--- a/vscripts/ui/ui_utility.gnut
+++ b/vscripts/ui/ui_utility.gnut
@@ -517,7 +517,7 @@ void function ScriptCallback_UnlockAchievement( int achievementID )
 {
 	Assert( achievementID >= 0 && achievementID < achievements.MAX_ACHIVEMENTS, "Tried to unlock achievement with invalid enum value" )
 
-	#if R5DEV
+	#if DEVELOPER
 		string ref
 		foreach ( string _ref, int val in achievements )
 		{
@@ -529,7 +529,7 @@ void function ScriptCallback_UnlockAchievement( int achievementID )
 		printt( "#############################################" )
 		printt( "UNLOCKED ACHIEVEMENT:", ref, "(" + achievementID + ")" )
 		printt( "#############################################" )
-	#endif //R5DEV
+	#endif // DEVELOPER
 
 	Plat_UnlockAchievementByID( achievementID )
 }

--- a/vscripts/ui/ui_vscript.gnut
+++ b/vscripts/ui/ui_vscript.gnut
@@ -373,7 +373,7 @@ void function UICodeCallback_UIInit()
 
 	ShLoadouts_VMInit()
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( IsFullyConnected() ) // special cases to handle uiscript_reset in dev
 		{
 		}

--- a/vscripts/ui/userinfo.nut
+++ b/vscripts/ui/userinfo.nut
@@ -120,7 +120,7 @@ void function UpdateActiveUserInfoPanels()
 
 		if ( isReady )
 		{
-			#if R5DEV
+			#if DEVELOPER
 				RuiSetBool( rui, "hasUnknownItems", GetConVarBool( "grx_hasUnknownItems" ) )
 			#endif
 			RuiSetInt( rui, "count1", premiumBalance )

--- a/vscripts/unitframes/cl_unitframes.gnut
+++ b/vscripts/unitframes/cl_unitframes.gnut
@@ -13,7 +13,7 @@ global function AddCallback_OnTeamUnitFrameDestroyed
 
 global function SetUnitFrameDataFromOwner
 
-#if R5DEV
+#if DEVELOPER
 global function PrintUnitFrames
 global function PrintTeammates
 #endif
@@ -467,7 +467,7 @@ entity function UnitFrame_GetOwnerByIndex( int index )
 	return null
 }
 
-#if R5DEV
+#if DEVELOPER
 void function PrintUnitFrames()
 {
 	printt( "file.teamUnitFrames size:", file.teamUnitFrames.len() )
@@ -485,7 +485,7 @@ void function PrintTeammates( entity player )
 		printt( "team:", team, "teammate:", p )
 	}
 }
-#endif // R5DEV
+#endif // DEVELOPER
 
 void function AddCallback_OnTeamUnitFrameCreated( void functionref(int) callbackFunc )
 {

--- a/vscripts/weapons/_vortex.nut
+++ b/vscripts/weapons/_vortex.nut
@@ -1269,7 +1269,7 @@ void function Vortex_ProjectileCommonSetup( entity projectile, VortexImpact impa
 void function Vortex_SetImpactEffectTable_OnProjectile( entity projectile, VortexImpact impact )
 {
 	//Getting more info for bug 207595, don't check into Staging.
-	#if R5DEV
+	#if DEVELOPER
 	//printt( "impactData.impact_effect_table ", impactData.impact_effect_table )
 	//if ( impactData.impact_effect_table == "" )
 	//	PrintTable( impactData )

--- a/vscripts/weapons/_weapon_utility.nut
+++ b/vscripts/weapons/_weapon_utility.nut
@@ -79,9 +79,9 @@ global function ServerCallback_SetWeaponPreviewState
 global function GetRadiusDamageDataFromProjectile
 global function OnWeaponAttemptOffhandSwitch_Never
 
-#if R5DEV
+#if DEVELOPER
 global function DevPrintAllStatusEffectsOnEnt
-#endif // #if R5DEV
+#endif // #if DEVELOPER
 
 #if SERVER
 global function PassThroughDamage
@@ -129,7 +129,7 @@ global function TryApplyingBurnDamage
 global function AddEntityBurnDamageStack
 global function ApplyBurnDamageTick
 
-#if R5DEV
+#if DEVELOPER
 global function ToggleZeroingMode
 #endif
 
@@ -242,7 +242,7 @@ struct
 
 		table<string, array<void functionref( entity, string, bool )> > weaponModChangedCallbacks
 
-		#if R5DEV
+		#if DEVELOPER
 			bool inZeroingMode = false
 		#endif
 
@@ -1522,7 +1522,7 @@ void function SatchelThink( entity satchel, entity player )
 	int satchelHealth = 15
 	thread TrapExplodeOnDamage( satchel, satchelHealth )
 
-	#if R5DEV
+	#if DEVELOPER
 		// temp HACK for FX to use to figure out the size of the particle to play
 		if ( Flag( "ShowExplosionRadius" ) )
 			thread ShowExplosionRadiusOnExplode( satchel )
@@ -1613,7 +1613,7 @@ void function PROTO_ExplodeAfterDelay( entity satchel, float delay )
 }
 #endif // SERVER
 
-#if R5DEV
+#if DEVELOPER
 void function ShowExplosionRadiusOnExplode( entity ent )
 {
 	ent.WaitSignal( "OnDestroy" )
@@ -1626,7 +1626,7 @@ void function ShowExplosionRadiusOnExplode( entity ent )
 	thread DebugDrawCircle( org, angles, innerRadius, 255, 255, 51, true, 3.0 )
 	thread DebugDrawCircle( org, angles, outerRadius, 255, 255, 255, true, 3.0 )
 }
-#endif // DEV
+#endif // DEVELOPER
 
 #if SERVER
 // shared between nades, satchels and laser mines
@@ -2834,7 +2834,7 @@ void function GiveEMPStunStatusEffects( entity ent, float duration, float fadeou
 	#endif
 }
 
-#if R5DEV
+#if DEVELOPER
 string ornull function FindEnumNameForValue( table searchTable, int searchVal )
 {
 	foreach ( string keyname, int value in searchTable )
@@ -2864,7 +2864,7 @@ void function DevPrintAllStatusEffectsOnEnt( entity ent )
 	}
 	printt( found + " effects active.\n" )
 }
-#endif // #if R5DEV
+#endif // #if DEVELOPER
 
 entity function GetMeleeWeapon( entity player )
 {
@@ -4580,7 +4580,7 @@ void function AddEntityBurnDamageStack( entity ent, entity owner, entity inflict
 	else if ( ent.IsNPC() )
 		ent.ai.burnDamageStacks.append( stack )
 
-	#if R5DEV && DEBUG_BURN_DAMAGE
+	#if DEVELOPER && DEBUG_BURN_DAMAGE
 		printt( "tickInterval:", stack.tickInterval )
 		printt( "numIntervals:", numIntervals )
 		printt( "damagePerTick:", stack.damagePerTick )
@@ -4600,7 +4600,7 @@ void function RemoveEntityBurnDamageStack( entity ent, int stackIdx )
 	else if ( ent.IsNPC() )
 		ent.ai.burnDamageStacks.remove( stackIdx )
 
-	#if R5DEV && DEBUG_BURN_DAMAGE
+	#if DEVELOPER && DEBUG_BURN_DAMAGE
 		printt( "burn stack removed, num stacks is now:", GetEntityBurnDamageStackCount( ent ) )
 	#endif
 }
@@ -4614,7 +4614,7 @@ void function EntityBurnDamageThread( entity ent )
 	OnThreadEnd(
 		function () : ( ent )
 		{
-			#if R5DEV && DEBUG_BURN_DAMAGE
+			#if DEVELOPER && DEBUG_BURN_DAMAGE
 				printt( "EntityBurnDamageThread ended" )
 			#endif
 
@@ -4643,7 +4643,7 @@ void function EntityBurnDamageThread( entity ent )
 					dmgThisTick += remainderDmg
 					stack.damageDealt += remainderDmg
 
-					#if R5DEV && DEBUG_BURN_DAMAGE
+					#if DEVELOPER && DEBUG_BURN_DAMAGE
 						printt( "applying", remainderDmg, "burn damage remainder, total damage dealt:", stack.damageDealt )
 					#endif
 				}
@@ -4654,7 +4654,7 @@ void function EntityBurnDamageThread( entity ent )
 				stack.damageDealt += stack.damagePerTick
 				stack.lastDamageTime = Time()
 
-				#if R5DEV && DEBUG_BURN_DAMAGE
+				#if DEVELOPER && DEBUG_BURN_DAMAGE
 					printt( "applying", stack.damagePerTick, "burn damage, total damage dealt:", stack.damageDealt )
 				#endif
 			}
@@ -4736,7 +4736,7 @@ void function SetEntityIsBurning( entity ent, bool isBurning )
 }
 
 
-#if R5DEV
+#if DEVELOPER
 void function ToggleZeroingMode()
 {
 	if ( !GetPlayerArray().len() )
@@ -4849,7 +4849,7 @@ bool function OnWeaponAttemptOffhandSwitch_Never( entity weapon )
 #if CLIENT
 void function ServerCallback_SetWeaponPreviewState( bool newState )
 {
-	#if R5DEV
+	#if DEVELOPER
 		entity player = GetLocalClientPlayer()
 
 		if ( newState )

--- a/vscripts/weapons/mp_ability_hunt_mode.nut
+++ b/vscripts/weapons/mp_ability_hunt_mode.nut
@@ -6,7 +6,7 @@ global function OnWeaponDeactivate_hunt_mode
 #if SERVER
 global function BurnMeter_HuntMode
 #endif //SERVER
-#if R5DEV && CLIENT 
+#if DEVELOPER && CLIENT 
 global function GetBloodhoundColorCorrectionID
 #endif //
 
@@ -318,7 +318,7 @@ void function StopHuntMode()
 	#endif
 }
 
-#if R5DEV && CLIENT 
+#if DEVELOPER && CLIENT 
 int function GetBloodhoundColorCorrectionID()
 {
 	return file.colorCorrection

--- a/vscripts/weapons/mp_weapon_mdlspawner.nut
+++ b/vscripts/weapons/mp_weapon_mdlspawner.nut
@@ -25,13 +25,13 @@ struct {
 
 void function MDLSpawner_Init()
 {
-	#if SERVER && R5DEV
+	#if SERVER && DEVELOPER
 	printt("adding mdlspawner ccc")
 	AddClientCommandCallback( "setmdl", ClientCommand_SetMDLSpawnerModel )
 	#endif
 }
 
-#if SERVER && R5DEV
+#if SERVER && DEVELOPER
 bool function ClientCommand_SetMDLSpawnerModel( entity player, array<string> args )
 {
 	if(args.len() == 0)

--- a/vscripts/weapons/mp_weapon_mdlspawner.nut
+++ b/vscripts/weapons/mp_weapon_mdlspawner.nut
@@ -6,7 +6,7 @@ global function MDLSpawner_Init
 #if SERVER
 global function OnWeaponNpcPrimaryAttack_weapon_mdlspawner
 global function ClientCommand_SetMDLSpawnerModel
-#endif // #if SERVER
+#endif // SERVER
 
 const MASTIFF_BLAST_PATTERN_LEN = 1
 
@@ -25,13 +25,13 @@ struct {
 
 void function MDLSpawner_Init()
 {
-	#if SERVER && DEVELOPER
+	#if SERVER
 	printt("adding mdlspawner ccc")
 	AddClientCommandCallback( "setmdl", ClientCommand_SetMDLSpawnerModel )
-	#endif
+	#endif // SERVER
 }
 
-#if SERVER && DEVELOPER
+#if SERVER
 bool function ClientCommand_SetMDLSpawnerModel( entity player, array<string> args )
 {
 	if(args.len() == 0)
@@ -55,7 +55,7 @@ var function OnWeaponNpcPrimaryAttack_weapon_mdlspawner( entity weapon, WeaponPr
 {
 	return FireMastiff( attackParams, false, weapon )
 }
-#endif // #if SERVER
+#endif // SERVER
 
 int function FireMastiff( WeaponPrimaryAttackParams attackParams, bool playerFired, entity weapon )
 {
@@ -119,7 +119,7 @@ int function FireMastiff( WeaponPrimaryAttackParams attackParams, bool playerFir
 void function MDLSpawner_SpawnModel( )
 {
 	#if SERVER
-	entity player = gp()[0]
+	entity player = GetPlayerArray()[0]
 	TraceResults tr = TraceLine(
 		player.EyePosition(), player.EyePosition() + 300.0 * player.GetViewVector(),
 		[ player ], TRACE_MASK_NPCWORLDSTATIC, TRACE_COLLISION_GROUP_NONE
@@ -137,5 +137,5 @@ void function MDLSpawner_SpawnModel( )
 	ent.kv.solid = SOLID_VPHYSICS
 	ent.Solid()
 	DispatchSpawn( ent )
-	#endif
+	#endif // SERVER
 }

--- a/vscripts/weapons/mp_weapon_thermite_grenade.nut
+++ b/vscripts/weapons/mp_weapon_thermite_grenade.nut
@@ -257,7 +257,7 @@ array<SegmentData> function CreateSpreadPattern( entity owner, entity inflictor,
 		}
 		firstTrace = false
 
-		#if R5DEV && DEBUG_THERMITE_GRENADE_TRACES
+		#if DEVELOPER && DEBUG_THERMITE_GRENADE_TRACES
 			DebugDrawLine( traceStart, traceEndUnder, 0, 255, 0, true, 25.0 )
 		#endif
 
@@ -268,7 +268,7 @@ array<SegmentData> function CreateSpreadPattern( entity owner, entity inflictor,
 		TraceResults forwardTrace = TraceLine( traceStart, traceEndUnder, ignoreArray, TRACE_MASK_SHOT, TRACE_COLLISION_GROUP_BLOCK_WEAPONS )
 		if ( forwardTrace.fraction == 1.0 )
 		{
-			#if R5DEV && DEBUG_THERMITE_GRENADE_TRACES
+			#if DEVELOPER && DEBUG_THERMITE_GRENADE_TRACES
 				DebugDrawLine( forwardTrace.endPos, forwardTrace.endPos + <0,0,-225>, 255, 0, 0, true, 25.0 )
 			#endif
 
@@ -293,7 +293,7 @@ array<SegmentData> function CreateSpreadPattern( entity owner, entity inflictor,
 
 		TraceResults upwardTrace = TraceLine( traceStart, traceEndOver, ignoreArray, TRACE_MASK_SHOT, TRACE_COLLISION_GROUP_BLOCK_WEAPONS )
 
-		#if R5DEV && DEBUG_THERMITE_GRENADE_TRACES
+		#if DEVELOPER && DEBUG_THERMITE_GRENADE_TRACES
 			DebugDrawLine( traceStart, traceEndOver, 0, 0, 255, true, 25.0 )
 		#endif
 
@@ -321,7 +321,7 @@ array<SegmentData> function CreateSpreadPattern( entity owner, entity inflictor,
 		}
 	}
 
-	#if R5DEV && DEBUG_THERMITE_GRENADE_TRACES
+	#if DEVELOPER && DEBUG_THERMITE_GRENADE_TRACES
 		printt( "Total segments:", segmentsArray.len() )
 	#endif
 

--- a/vscripts/weapons/sh_care_package.nut
+++ b/vscripts/weapons/sh_care_package.nut
@@ -208,7 +208,7 @@ int function GetSkinForCarePackageModel( entity player )
 {
 	LoadoutEntry characterSlot = Loadout_CharacterClass()
 
-	#if R5DEV
+	#if DEVELOPER
 		if ( !LoadoutSlot_IsReady( ToEHI( player ), characterSlot ) )
 			printt( "Need to get character for player, but the data is not available" )
 	#endif
@@ -216,7 +216,7 @@ int function GetSkinForCarePackageModel( entity player )
 	ItemFlavor character = LoadoutSlot_WaitForItemFlavor( ToEHI( player ), characterSlot ) // this sometimes waits forever
 	string characterRef = ItemFlavor_GetHumanReadableRef( character )
 
-	#if R5DEV
+	#if DEVELOPER
 		printt( "got character", characterRef )
 	#endif
 


### PR DESCRIPTION
The "DEV" global define was never set in this retail engine, even when the engine was launched with "-dev", or when "developer" ConVar was set, and the ScriptVM was reset. It caused confusion because the DEV define DOES work in the RSON files. In the early days of this project (before it was released), we renamed all DEV macro's to R5DEV and set this global const to true in init.nut. This was a dirty solution, because it forces all development scripts, and even caused compile errors when the game was not launched with "-dev", because the RSON files WON'T compile anything under DEV blocks, but the scripts do expect them as R5DEV was always true. The SDK registers a constant called "DEVELOPER" with the value of the developer ConVar. The reason it had to be renamed from "R5DEV" to "DEVELOPER" was to avoid confusion with left over Jira tickets, the reason we couldn't use "DEV" was because it's already defined, but as NULL. Using all the effort to perform inline asm hooking to swap the value with that of the "developer" ConVar was not worth it.