### PR TITLE
Fixed that the ISAIMTRAINER variable is not false and the aimtrainer …

### DIFF
--- a/vscripts/ui/R5RMenus/menu_lobby.nut
+++ b/vscripts/ui/R5RMenus/menu_lobby.nut
@@ -169,6 +169,11 @@ void function OnR5RLobby_Open()
 	server_host_name = ""
 
 	RunClientScript("UICallback_SetHostName", GetPlayerName() + "'s Lobby")
+
+	while ISAIMTRAINER
+	{
+		ISAIMTRAINER = false
+	}
 }
 
 void function SetupLobby()


### PR DESCRIPTION
Fixed that the ISAIMTRAINER variable is not false and the aimtrainer menu will still be opened after the lobby exits the settings menu