### PR TITLE
Refactor anti-afk functionality

### DIFF
--- a/vscripts/gamemodes/custom_ctf/_gamemode_custom_ctf.nut
+++ b/vscripts/gamemodes/custom_ctf/_gamemode_custom_ctf.nut
@@ -237,6 +237,7 @@ void function ResetMapVotes()
 
 void function RUNCTF()
 {
+    AntiAfkInit()
     WaitForGameState(eGameState.Playing)
 
     for( ; ; )

--- a/vscripts/gamemodes/custom_tdm/_gamemode_flowstate.nut
+++ b/vscripts/gamemodes/custom_tdm/_gamemode_flowstate.nut
@@ -1936,6 +1936,7 @@ void function GiveGungameWeapon(entity player) {
 void function RunTDM()
 //By Retículo Endoplasmático#5955 (CaféDeColombiaFPS)//
 {
+	AntiAfkInit()
     WaitForGameState(eGameState.Playing)
     AddSpawnCallback("prop_dynamic", _OnPropDynamicSpawned)
 

--- a/vscripts/mp/_antiafk.nut
+++ b/vscripts/mp/_antiafk.nut
@@ -1,0 +1,126 @@
+untyped
+global function AntiAfkInit
+
+enum eAntiAfkPlayerState
+{
+	ACTIVE
+	SUSPICIOUS
+    AFK
+}
+
+struct {
+    table<entity, float> lastmoved = {}
+} file
+
+void function AntiAfkInit() {
+    if ( GetCurrentPlaylistVarBool( "Flowstate_antiafk_Enabled", true )) {
+        AddCallback_GameStateEnter( eGameState.Playing, Playing )
+    }
+}
+
+// possibly todo: add convar/playlistvar for non-admin players to avoid afk kicks
+bool function IsImmuneAfkKick( entity player ){
+    if( !IsValid(player) ) return false
+    return IsAdmin(player)
+}
+
+void function Playing(){
+    AddCallback_OnClientConnected( AddPlayerCallbacks )
+    AddCallback_OnClientDisconnected( DeletePlayerRecords )
+    // What exactly is respawning? kill_self doesn't trigger this callback?
+    // AddCallback_OnPlayerRespawned( Moved )
+
+    foreach (entity player in GetPlayerArray()){
+        AddPlayerCallbacks( player )
+		Moved( player )
+    }
+
+    thread CheckAfkKickThread()
+}
+
+int function GetAfkState( entity player ){
+    float localgrace = GetCurrentPlaylistVarFloat( "Flowstate_antiafk_grace", 180.0 )
+    float warn = GetCurrentPlaylistVarFloat( "Flowstate_antiafk_warn", 120.0 )
+
+    // different grace when dead
+    if ( !IsAlive( player ) ){
+        localgrace = GetCurrentPlaylistVarFloat( "Flowstate_antiafk_gracedead", 380.0 )
+    }
+
+    if ( player in file.lastmoved ){
+        float lastmove = file.lastmoved[ player ]
+        if (Time() > lastmove + ( localgrace - warn )){
+
+            if ( Time() > lastmove + localgrace ){
+                return eAntiAfkPlayerState.AFK
+            }
+
+            return eAntiAfkPlayerState.SUSPICIOUS
+        }
+    }
+    return eAntiAfkPlayerState.ACTIVE
+}
+
+void function AfkWarning( entity player ){
+        Message( player, "AFK WARNING", "\n You are AFK. You will be kicked unless you begin playing." )
+}
+
+void function CheckAfkKickThread(){
+    while (true){
+        if ( GetGameState() == eGameState.Playing ){
+            foreach (entity player in GetPlayerArray()){
+
+                // guard player missing
+                if ( !player.IsPlayer() ){
+                    DeletePlayerRecords( player )
+                    return
+                }
+
+                if (IsImmuneAfkKick( player )){ 
+                    return
+                }
+
+                int afkstate = GetAfkState( player )
+
+                switch ( afkstate ){
+
+                    case eAntiAfkPlayerState.SUSPICIOUS:
+                        AfkWarning( player )
+                        break
+
+                    case eAntiAfkPlayerState.AFK:
+					    ClientCommand( player, "disconnect" )
+                        break
+                }
+            }
+        }
+        wait GetCurrentPlaylistVarFloat( "Flowstate_antiafk_interval", 5.0 )
+    }
+}
+
+void function Moved( entity player ){
+    file.lastmoved[ player ] <- Time()
+}
+
+
+void function AddPlayerCallbacks( entity player ){
+	AddButtonPressedPlayerInputCallback( player, IN_ATTACK, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_JUMP, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_DUCK, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_FORWARD, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_BACK, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_USE, Moved )
+
+	// wtf is the difference between moveleft/left + moveright/right? Does this work with controller?
+	AddButtonPressedPlayerInputCallback( player, IN_LEFT, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_RIGHT, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_MOVELEFT, Moved )
+	AddButtonPressedPlayerInputCallback( player, IN_MOVERIGHT, Moved )
+    Moved( player )
+}
+
+void function DeletePlayerRecords( entity player ){
+    if ( player in file.lastmoved ){
+        delete file.lastmoved[ player ]
+    }
+}

--- a/vscripts/mp/_codecallbacks.gnut
+++ b/vscripts/mp/_codecallbacks.gnut
@@ -61,35 +61,35 @@ void function OnClientConnected( entity player )
 	thread RecordPositions(player)
 	
 	//Afk autokick thread. Colombia
-	if(GameRules_GetGameMode() == "custom_tdm" || GameRules_GetGameMode() == "custom_ctf")
-		thread Flowstate_CheckPlayerIsAFK(player)
+	// if(GameRules_GetGameMode() == "custom_tdm" || GameRules_GetGameMode() == "custom_ctf")
+	// 	thread Flowstate_CheckPlayerIsAFK(player)
 	
 	// AccumulatedDamageData damageData
 	// file.playerAccumulatedDamageData[player] <- damageData
 }
 
-void function Flowstate_CheckPlayerIsAFK(entity player)
-{
-	int finishTime
-	while(IsValid(player) && !IsAdmin(player))
-	{
-		if(player.GetVelocity().Length() == 0)
-		{
-			finishTime = int(Time()) + 180
-			while(IsValid(player) && IsAlive(player) && !player.p.isSpectating && player.GetVelocity().Length() == 0 && Time() < finishTime && GetGameState() == eGameState.Playing)
-			{
-				if(finishTime-int(Time()) == 10)
-					Message(player, "AFK ALERT", "You're afk, server will kick you if you don't move in the next 10 seconds.")
-				
-				if(finishTime-int(Time()) == 1)
-					ClientCommand( player, "disconnect" )
-			
-				wait 1
-			}
-		}
-		wait 1
-	}	
-}
+// void function Flowstate_CheckPlayerIsAFK(entity player)
+// {
+// 	int finishTime
+// 	while(IsValid(player) && !IsAdmin(player))
+// 	{
+// 		if(player.GetVelocity().Length() == 0)
+// 		{
+// 			finishTime = int(Time()) + 180
+// 			while(IsValid(player) && IsAlive(player) && !player.p.isSpectating && player.GetVelocity().Length() == 0 && Time() < finishTime && GetGameState() == eGameState.Playing)
+// 			{
+// 				if(finishTime-int(Time()) == 10)
+// 					Message(player, "AFK ALERT", "You're afk, server will kick you if you don't move in the next 10 seconds.")
+//				
+// 				if(finishTime-int(Time()) == 1)
+// 					ClientCommand( player, "disconnect" )
+//			
+// 				wait 1
+// 			}
+// 		}
+// 		wait 1
+// 	}	
+// }
 
 // TODO: Get an equivalent callback happening on the client, so we can stop using ServerCallback_PlayerTookDamage which is always out of date to some degree.
 void function CodeCallback_DamagePlayerOrNPC( entity ent, var damageInfo )

--- a/vscripts/scripts.rson
+++ b/vscripts/scripts.rson
@@ -435,6 +435,7 @@ Scripts:
 	ai/_titan_npc_behavior.gnut
 	conversation/_conversation_schedule.gnut
 	mp/_ai_superspectre.nut
+	mp/_antiafk.nut
 	mp/_base_gametype.gnut
 	mp/_changemap.nut
 	mp/_codecallbacks.gnut


### PR DESCRIPTION
This PR makes the AFK check more robust, and should work for the 1v1 DM servers, which the current AFK check is broken for. Uses `AddButtonPressedPlayerInputCallback` instead of velocity checks. Currently, certain spawnpoints for the 1v1 server are slightly above the ground, causing players to fall for a short moment and gain velocity, which flags them as not AFK. AFK players also die during 1v1s, which also circumvents the current AFK check.

90% of code yoinked from [laundmo's AntiAFK for Northstar](https://northstar.thunderstore.io/package/laundmo/AntiAFK/). Refactored some stuff to work with R5R, otherwise I did not make many changes to laundmo's code.

I've tested locally, things appear to work for most edge cases, however I can't host a server(can't port forward in my apartment) so I can't completely test everything.

**Need someone to test that this is confirmed working for a few edge cases:**
1. Not sure if this will kick players that are spectating(it shouldn't?)
2. I don't own a controller, therefore I can't test for it. No idea if `AddButtonPressedPlayerInputCallback` works for controller.
3. Should work if killed by another player, however I was only able to test this with `kill_self`. Have not tested by being shot & killed by another player.

If someone is willing to host a server with these scripts, I'd gladly hop on the server to test with you.