### PR TITLE
S17 weapons values

### DIFF
--- a/weapons/mp_weapon_defender.txt
+++ b/weapons/mp_weapon_defender.txt
@@ -79,11 +79,10 @@ WeaponData
 	"uses_ammo_pool"								"1"
 	"ammo_pool_type"								"sniper"
 
-	"ammo_clip_size"   								"8"
     "ammo_default_total"							"24"
     "ammo_stockpile_max"							"24"
     "ammo_no_remove_from_stockpile"					"0"
-	"ammo_clip_size"   								"8"
+	"ammo_clip_size"   								"6"
 	"ammo_min_to_fire"								"2"
 	"ammo_per_shot"                                 "2"
 	"low_ammo_fraction" 							"0.34"

--- a/weapons/mp_weapon_doubletake.txt
+++ b/weapons/mp_weapon_doubletake.txt
@@ -3,7 +3,7 @@
 
                    
 #base "_base_mags_energy.txt"
-      
+
 
 #base "_base_stocks_sniper.txt"
 
@@ -17,7 +17,7 @@
 	"longdesc"                                     "#WPN_DOUBLETAKE_LONGDESC"
 
 	"weapon_type_flags"								"WPT_PRIMARY"
-	
+
 	// UI - HUD
 	"menu_icon"										"rui/weapon_icons/r5/weapon_triple_take"
 	"hud_icon"										"rui/weapon_icons/r5/weapon_triple_take"
@@ -75,10 +75,10 @@
 
 	// Behavior - ADS (tied to animation)
 	//
-	"ads_fov_zoomfrac_start"                "0.2"
-    "ads_fov_zoomfrac_end"                  "0.9"
-    "viewmodel_offset_zoom_frac_start"      "0.2"
-    "viewmodel_offset_zoom_frac_end"        "0.9"
+	"ads_fov_zoomfrac_start"                       "0.2"
+    "ads_fov_zoomfrac_end"                         "0.9"
+    "viewmodel_offset_zoom_frac_start"             "0.2"
+    "viewmodel_offset_zoom_frac_end"               "0.9"
 
 	// Damage
 	//
@@ -116,7 +116,7 @@
 	// energy weapons have less drop
 	"projectile_drag_coefficient" 					"0.0"
 
-	"bolt_hitsize"									"0.0"
+	"bolt_hitsize"									"0.25"
 
     //"bolt_hitsize_grow1_time"				        "0.123"  //~100m
     //"bolt_hitsize_grow1_size"				        "0.33"
@@ -129,19 +129,27 @@
 	"projectile_spread_choke_frac_1" 				"1.0"
 	"projectile_spread_choke_frac_2" 				"0.60"
 	"projectile_spread_choke_frac_3" 				"0.25"
-	"projectile_spread_choke_frac_4" 				"0.05"
+	"projectile_spread_choke_frac_4" 				"0.01"
 
 	// Ammo
 	//
-
-	"ammo_pool_type"                               "special"
-	"ammo_clip_size"                               "18"
-	"ammo_stockpile_max"                           "120"
-	"ammo_default_total"                           "120"
-	"ammo_per_shot"                                "3"
-	"ammo_min_to_fire"                             "3"
+                        
+                                  
+                                                                               
+                                   
+                                                        
+                                           
+                               
+     
+	"ammo_clip_size"   							    "6"
+    "ammo_default_total"							"0"
+    "ammo_no_remove_from_stockpile"					"1"
+    "uses_ammo_pool"								"1"
+    "ammo_pool_type"								"special"
+      
+	"ammo_per_shot"                                "1"
+	"ammo_min_to_fire"                             "1"
 	"ammo_clip_random_loss_on_npc_drop_chunksize"  "1"
-	"ammo_no_remove_from_stockpile"                "1"
 	"reload_enabled"                               "1"
 	"allow_empty_click"                            "1"
 	"empty_reload_only"                            "0"
@@ -201,11 +209,11 @@
 
 	// Spread
 	//
-	"spread_stand_hip"                         "4"
-	"spread_stand_hip_run"                     "6"
-	"spread_stand_hip_sprint"                  "7"
-	"spread_crouch_hip"                        "3"
-	"spread_air_hip"                           "8"
+	"spread_stand_hip"                         "3"
+	"spread_stand_hip_run"                     "5"
+	"spread_stand_hip_sprint"                  "6"
+	"spread_crouch_hip"                        "2.25"
+	"spread_air_hip"                           "7"
 
 	"spread_stand_ads"						    "0"
     "spread_crouch_ads"   					    "0"
@@ -229,9 +237,9 @@
 	//
 	"fire_sound_1_npc"                             "Weapon_DoubleTake_Fire_NPC"
 	"fire_sound_1_player_1p"                       "Weapon_DoubleTake_Fire_1P"
-	"fire_sound_2_player_1p"                       "large_shell_drop"
+	//"fire_sound_2_player_1p"                       "large_shell_drop"
 	"fire_sound_1_player_3p"                       "Weapon_DoubleTake_Fire_3P"
-	"fire_sound_2_player_3p"                       "large_shell_drop"
+	//"fire_sound_2_player_3p"                       "large_shell_drop"
 
 	// Sound - Low Ammo
 	"low_ammo_sound_name_1"                        "DoubleTake_LowAmmo_Shot1"
@@ -300,9 +308,12 @@
 	"projectile_trail_effect_0"                    "P_tracer_proj_sniper_blue"
 
 	// FX
-	"fx_muzzle_flash_view"							""
-	"fx_muzzle_flash_world"							""
-	"fx_muzzle_flash_attach"						""
+	"fx_muzzle_flash_view"                         "P_wpn_mflash_dbltake_FP"
+	"fx_muzzle_flash_world"                        "P_wpn_mflash_dbltake"
+
+	"fx_shell_eject_attach"                    "shell"
+    "fx_muzzle_flash_attach_scoped"            "muzzle_flash_scoped"
+
 	// FX - Shells
 	"fx_shell_eject_attach_scoped" 					"shell"
 	"fx_shell_eject2_attach" 						"shell_L"
@@ -339,11 +350,16 @@
     "burn_tick_rate"                "0.8"       //how often we do a damage tick = (tick_rate / burn_time)
     "sound_burn_damage_tick_1p" 	"flesh_thermiteburn_3p_vs_1p"
 
+	"viewmodel_ads_rui_bottomleft_attachment"	"RUI_BL_CROSSHAIR_TRIPLETAKE"
+	"viewmodel_ads_centerpoint_attachment"      "ADS_CENTER_SIGHT_TRIPLETAKE"
+
+	"player_overheat_per_bullet"        "28"
+
 	"Mods"
 	{
 	    gold
-	    {
-	    }
+        {
+        }
 
 		"survival_finite_ammo"
 		{
@@ -544,17 +560,17 @@
 
 		energy_mag_l1
 		{
-			"ammo_clip_size"   					"21"
+			"ammo_clip_size"   					"7"
 		}
 
 		energy_mag_l2
 		{
-			"ammo_clip_size"   					"24"
+			"ammo_clip_size"   					"8"
 		}
 
 		energy_mag_l3
 		{
-			"ammo_clip_size"   					"27"
+			"ammo_clip_size"   					"10"
 		}
       
 
@@ -618,6 +634,7 @@
 			vis					player_zoomfrac
 			charge				player_chargeFrac
 			chargeEnabled		eWeaponVar.custom_int_0
+			centerOffset		weapon_ads_center_offset
 		}
 	}
 

--- a/weapons/mp_weapon_lstar.txt
+++ b/weapons/mp_weapon_lstar.txt
@@ -1,7 +1,8 @@
 #base "_base_lmg.txt"
-#base "_base_barrels_large.txt"
-#base "_base_mags_energy.txt"
+#base "_base_barrels_medium.txt"
 #base "_base_stocks_tactical.txt"
+
+#base "_base_mags_energy.txt"
 
 WeaponData
 {
@@ -14,7 +15,7 @@ WeaponData
 	"menu_icon"										"rui/weapon_icons/r5/weapon_lstar"
 	"hud_icon"										"rui/weapon_icons/r5/weapon_lstar"
 	"ammo_pool_type"								"special"
-	
+
 	"weapon_type_flags"								"WPT_PRIMARY"
 	"weaponClass" 									"human"
 	"body_type"										"stalker"
@@ -22,12 +23,14 @@ WeaponData
 	"pickup_hold_prompt"  							"Hold [USE] [WEAPONNAME]"
 	"pickup_press_prompt" 							"[USE] [WEAPONNAME]"
 	"leveled_pickup"								"1"
+	 "ammo_pool_type"                                "special"
 
 	"cooldown_type"									"chargeFrac"
     "cooldown_time"	                                "0.4" // actually, "blowoff animation time"
     "charge_time"                                   "2.4"  // while holding trigger, time until weapon overheats
-    "charge_cooldown_time"                          "2.45"  // controls length of overheat anim (along with delay)
-    "charge_cooldown_delay"                         "0.08"
+    "charge_cooldown_time"                          "3.63"  // controls length of overheat anim (along with delay)
+    "charge_cooldown_delay"                         "0.06"
+	
 	"charge_overheats_when_full"                    "1"
 	"charge_weapon_fires_while_charging"            "1"
 	"charge_remain_full_when_fired"                 "1"
@@ -35,7 +38,7 @@ WeaponData
 
                      
     "projectile_launch_speed"                       "24000"
-     
+
                                        
       
 	"projectile_drag_coefficient" 					"0.0"
@@ -64,20 +67,21 @@ WeaponData
 	"playermodel" 									"mdl/weapons/lstar/w_lstar.rmdl"
 	"projectilemodel" 								"mdl/dev/empty_model.rmdl"
 	"holster_type"									"rifle"
+	"holster_offset"								"8 0 0"
 
 	// Effects
 	"projectile_trail_effect_0" 					"P_projectile_lstar"
 	"impact_effect_table" 							"lstar"
 	"projectile_adjust_to_gun_barrel"				"1"
 
-	"fx_muzzle_flash_view"							""
-	"fx_muzzle_flash_world"							""
-	"fx_muzzle_flash_attach"						""
+	"fx_muzzle_flash_view"							"P_muz_lstar_FP"
+	"fx_muzzle_flash_world"							"P_muz_lstar"
+	"fx_muzzle_flash_attach"						"muzzle_flash"
 
 	//Sounds
 	"fire_sound_1_player_1p"						"Weapon_LSTAR_Fire_1P"
 	//"fire_sound_1_player_3p"						"Weapon_LSTAR_Fire_3P"
-	"fire_sound_2_player_1p"						"weapon_lstar_secondshot_1p"
+	//"fire_sound_2_player_1p"						"weapon_lstar_secondshot_1p"
 	"fire_sound_2_player_3p"						"Weapon_LSTAR_SecondShot_3P"
 
 	//"idle_sound_player_1p"							"weapon_lstar_idle_gears_1p"
@@ -128,19 +132,19 @@ WeaponData
 
 	"bolt_hitsize"									"0.0"
                      
-    "bolt_hitsize_grow1_time"						"0.03"
-	"bolt_hitsize_grow1_size"						"0.03"
-	"bolt_hitsize_grow2_time"						"0.065"
-	"bolt_hitsize_grow2_size"						"0.06"
-	"bolt_hitsize_growfinal_lerptime"				"0.14"
-	"bolt_hitsize_growfinal_size"					"1.0"
-     
-                                       
-                                     
+                                         
                                       
-                                     
+                                       
+                                      
                                             
                                         
+     
+	"bolt_hitsize_grow1_time"						"0.075"
+	"bolt_hitsize_grow1_size"						"1" //"5.0"
+	"bolt_hitsize_grow2_time"						"0.18"
+	"bolt_hitsize_grow2_size"						"2.5" //"7.0"
+	"bolt_hitsize_growfinal_lerptime"				"0.18"
+	"bolt_hitsize_growfinal_size"					"3.5" //"7.0"
       
 
 
@@ -288,7 +292,7 @@ WeaponData
 	"sprintcycle_time"								"0"
 
     // Viewkick
-    "viewkick_pattern"                              "lstar_4"
+    "viewkick_pattern"                              "lstar_3"
 
     "viewkick_spring" 								"lstar_vkp"
     "viewkick_spring_hot"                           "lstar_vkp_hot"
@@ -305,7 +309,11 @@ WeaponData
 
 	"viewkick_pitch_base" 							"1.0"
 	"viewkick_pitch_random"   						"1.0"
-	"viewkick_pitch_softScale"						"2.6"   //"2.0"
+                      
+                                                 
+      
+		"viewkick_pitch_softScale"						"2.0"   //"2.0"
+       
 	"viewkick_pitch_hardScale"						"0.4"
 
 	"viewkick_yaw_base"   							"1.0"
@@ -337,11 +345,11 @@ WeaponData
 	"viewkick_scale_pitch_valueLerpEnd" 			"0"
 	"viewkick_scale_yaw_valueLerpEnd" 				"5"
                      
-	"viewkick_scale_valueDecayDelay"  				"0.55"     //"0.25"
-    "viewkick_scale_valueDecayRate"   				"160"
-     
+                                                          
                                                
-                                              
+     
+    "viewkick_scale_valueDecayDelay"  				"0.1"
+    "viewkick_scale_valueDecayRate"   				"60"
       
 
 
@@ -378,31 +386,46 @@ WeaponData
 	"viewdrift_ads_air_scale_yaw" 				"0.9"
 
 	// Ammo
-	"ammo_suck_behavior"							"primary_weapons"
-	"ammo_clip_size"   								"999"
-	"ammo_clip_reload_max"							"999"
+    "ammo_suck_behavior"							"primary_weapons"
+    "chance_for_bonus_last_shot_in_clip"			"0"
+    "critical_hit"									"1"
+
+
+                     
+                                                       
+                                        
+                                                       
+                                                                                      
+                                   
+                                    
+
+     
+
+	"ammo_clip_size"   								"0"
+	//"ammo_clip_reload_max"							"40"
 	"ammo_min_to_fire"								"1"
 	"ammo_per_shot"		    						"1"
-	"ammo_no_remove_from_stockpile"					"1"
-	"chance_for_bonus_last_shot_in_clip"			"0"
-	"critical_hit"									"1"
-
-    "ammo_stockpile_max"							"80"
-    "ammo_default_total"							"120"
-    "low_ammo_fraction" 							"0.005"
+	"ammo_no_remove_from_stockpile"					"0"
+    "low_ammo_fraction" 							"0.3"
+    "ammo_stockpile_max"                            "324"
+    "ammo_default_total"                            "324"    //for crate weapons, default total should be clip size + stockpile max
     "uses_ammo_pool"								"0"
+
+    "pass_through_depth"                            "64"
+    "pass_through_damage_preserved_scale"           "0.6"
+      
 
     "reload_alt_anim"								"0"
 
     "aimassist_adspull_weaponclass"					"none"
 
-    "damage_near_value"   							"17"
-    "damage_far_value"								"17"
-    "damage_very_far_value"							"17"
-    "damage_near_value_titanarmor"					"17"
-    "damage_far_value_titanarmor" 					"17"
-    "damage_very_far_value_titanarmor" 				"17"
-
+    "damage_near_value"   							"16"
+    "damage_far_value"								"16"
+    "damage_very_far_value"							"16"
+    "damage_near_value_titanarmor"					"16"
+    "damage_far_value_titanarmor" 					"16"
+    "damage_very_far_value_titanarmor" 				"16"
+	"damage_shield_scale"      			"1.6"
     "damage_rodeo" 									"100"
     "explosion_damage"								"30"
     "damage_near_distance"							"1500"
@@ -451,9 +474,9 @@ WeaponData
 
 	// Behavior
                      
-    "fire_rate"                                     "10.0"
+                                                          
      
-                              
+	"fire_rate"   									"10.0"
       
 
 	"zoom_time_in"                                  "0.34"
@@ -493,80 +516,300 @@ WeaponData
     //"clip_bodygroup_show_for_milestone_2"	"0"
     //"clip_bodygroup_show_for_milestone_3"	"0"
 
-               
-         
-  
-                                       
-                                       
-  
-      
+
+	"viewmodel_ads_rui_bottomleft_attachment"	"RUI_BL_CROSSHAIR_LSTAR"
+	"viewmodel_ads_centerpoint_attachment"      "ADS_CENTER_SIGHT_LSTAR"
+
 
 	Mods
 	{
-	    crate
-	    {
-	    }
 
-        survival_finite_ammo
-        {
-            "ammo_no_remove_from_stockpile"		"0"
-	   		"uses_ammo_pool"					"0"
-        }
+	survival_finite_ammo
+	{
+		"ammo_no_remove_from_stockpile"		"0"
+		   "uses_ammo_pool"					"0"
+	}
 
-		// R2 easter egg, to keep
-		rcee
-		{
-			"ui1_enable"		"0"
-			"ui3_enable"		"1"
-			"ammo_min_to_fire"	"0"
-			"dof_zoom_nearDepthStart"						"* 0.0"
-			"dof_zoom_nearDepthEnd"							"* 0.5"
-		}
+                        
+                        
+   
+                                                                 
+                                                                                  
+   
 
-        optic_cq_threat
-        {
-            // sight_cro
-            "zoom_fov"				"60"
-
-            "bodygroup1_set"		"0"
-            "bodygroup10_set"		"1"
-
-            //"ui1_enable"			"0"
-            "ui10_enable"			"1"
-
-            "mod_activity_modifier"	"optic"
-
-            "viewmodel_ads_rui_bottomleft_attachment"	"RUI_BL_CROSSHAIR_CRO"
-            "viewmodel_ads_centerpoint_attachment"      "ADS_CENTER_SIGHT_CRO"
-            "viewmodel_offset_ads_by_centerpoint" 		"1"
-
-            "viewmodel_offset_ads" 				        "0 10 0"
-            "dof_zoom_nearDepthStart"				    "0.5"
-            "dof_zoom_nearDepthEnd"					    "4.1"
-
-            "threat_scope_enabled"			    "1"
-            "threat_scope_fadedist_start"       "984"  // 25m
-            "threat_scope_fadedist_end"         "2165" // 55m
-            "threat_scope_bounds_tagname1"	    "SCR_TR_CRO"
-            "threat_scope_bounds_tagname2"	    "SCR_BL_CRO"
-
-	        "zoom_time_in"                          "0.36"
-	        "zoom_time_out"                         "0.32"
-
-            "anim_alt_idleAttack"                   "1"
-            "ads_fov_zoomfrac_start"                "0.1"
-            "ads_fov_zoomfrac_end"                  "0.8"
-            "viewmodel_offset_zoom_frac_start"      "0.1"
-            "viewmodel_offset_zoom_frac_end"        "0.8"
-        }
-
-               
-                                                                                                           
-                    
+                          
          
-                                                                                          
+                                              
+
+                               
+
+                                                                                                          
+                                                                
+
+                                                                                
+                                                                      
+
+                                        
+                                          
+                                                          
+
+                                   
+                                        
+                                                               
+
+                                     
+                                                
+                                           
+                                             
+
+                                    
+                                 
+                                     
+                                          
+                                          
+                                              
+                                
+
+                                          
+                                                   
+
+                                                        
+
+                                                                         
+                                                                         
+
+                                                                   
+                                                                 
+
+                                                    
+                                                              
+                                                               
+                                                              
+                                                              
+                                                           
+                                       
+   
+      
+
+                  
+                   
+         
          
       
+
+	//Stocks reduce the overheat lens change time as they would reduce reloads on other weapons.
+		"stock_tactical_l1"
+	    {
+            "cooldown_time"	                                "*0.967" //"0.4" // actually, "blowoff animation time"
+	    }
+        "stock_tactical_l2"
+        {
+            "cooldown_time"	                                "*0.933" //"0.4" // actually, "blowoff animation time"
+        }
+        "stock_tactical_l3"
+        {
+            "cooldown_time"	                                "*0.9" //"0.4" // actually, "blowoff animation time"
+        }
+
+	//Magazines allow the Lstar to shoot more before overheating and reduce the cooldown and delay so they cool off faster
+	//no mag = 22 shots
+        energy_mag_l1
+        {
+            "charge_cooldown_time"                          "*0.967"  // non-overheat
+            "charge_cooldown_delay"                         "*0.967"  //
+
+            "charge_time"                                   "2.6"     //26 shots
+        }
+        energy_mag_l2
+        {
+            "charge_cooldown_time"                          "*0.933"  // non-overheat
+            "charge_cooldown_delay"                         "*0.933"  //
+
+            "charge_time"                                   "2.8"     //28 shots
+        }
+        energy_mag_l3
+        {
+            "charge_cooldown_time"                          "*0.9"  // non-overheat
+            "charge_cooldown_delay"                         "*0.9"  //
+
+            "charge_time"                                   "3.0"   //30 shots
+        }
+        energy_mag_l4
+        {
+            "charge_cooldown_time"                          "*0.9"  // non-overheat
+            "charge_cooldown_delay"                         "*0.9"  //
+
+                                 
+                                                                                  
+                 
+                "charge_time"                                   "3.6"   //36 shots
+                  
+        }
+		barrel_stabilizer_l1
+        {
+            "bodygroup27_set"                   "1"
+
+            "fx_muzzle_flash_attach"	        "muzzle_flash_suppressor_medium"
+
+            "viewkick_pitch_base" 				"*0.97"
+            "viewkick_pitch_random"   			"*0.95"
+            "viewkick_yaw_base" 				"*0.97"
+            "viewkick_yaw_random"   			"*0.95"
+        }
+
+        barrel_stabilizer_l2
+        {
+            "bodygroup27_set"	                "1"
+
+            "fx_muzzle_flash_attach"	        "muzzle_flash_suppressor_medium"
+            "viewkick_pitch_base" 				"*0.94"
+            "viewkick_pitch_random"   			"*0.93"
+            "viewkick_yaw_base" 				"*0.94"
+            "viewkick_yaw_random"   			"*0.93"
+        }
+
+		barrel_stabilizer_l3
+		{
+		    "bodygroup27_set"	                "1"
+
+		    "fx_muzzle_flash_attach"	        "muzzle_flash_suppressor_medium"
+
+			"viewkick_pitch_base" 				"*0.9"
+			"viewkick_pitch_random"   			"*0.9"
+			"viewkick_yaw_base" 				"*0.9"
+			"viewkick_yaw_random"   			"*0.9"
+		}
+
+        optic_cq_hcog_classic
+        {
+            "ui1_enable"			"0"
+        }
+
+        optic_cq_hcog_bruiser
+        {
+            "ui1_enable"			"0"
+        }
+
+        optic_cq_holosight
+        {
+            "ui1_enable"			"0"
+        }
+
+        optic_cq_holosight_variable
+        {
+            "ui1_enable"			"0"
+        }
+
+        optic_ranged_hcog
+        {
+            "ui1_enable"			"0"
+        }
+
+        optic_ranged_aog_variable
+        {
+            "ui1_enable"			"0"
+        }
+
+
+	}
+
+
+    //classic
+    UiData6
+    {
+        "ui"	"ui/hcog_classic_sights"
+        "mesh" 	"models/weapons/attachments/hcog_classic_sights"
+        Args
+        {
+            vis							player_zoomfrac
+            ammo						weapon_ammoClipCount
+            clipSize					eWeaponVar.ammo_per_shot
+            centerOffset		        weapon_ads_center_offset
+            showChargeFrac              eWeaponVar.ammo_per_shot
+            chargeFrac                  player_chargeFrac
+        }
+    }
+
+    //bruiser
+    UiData7
+    {
+        "ui"						"ui/hcog_upper"
+        "mesh"						"models/weapons/attachments/hcog2_rui_upper"
+        Args
+        {
+            vis							player_zoomfrac
+            ammo						weapon_ammoClipCount
+            clipSize					eWeaponVar.ammo_per_shot
+            centerOffset		        weapon_ads_center_offset
+            showChargeFrac              eWeaponVar.ammo_per_shot
+            chargeFrac                  player_chargeFrac
+        }
+    }
+
+    //holo
+	UiData8
+	{
+		"ui"					"ui/holo_sights"
+		"mesh"					"models/weapons/attachments/holo_rui_upper"
+		Args
+		{
+			vis					player_zoomfrac
+			ammo				weapon_ammoClipCount
+			clipSize			eWeaponVar.ammo_per_shot
+			clipCount			eWeaponVar.ammo_per_shot
+			centerOffset		weapon_ads_center_offset
+			showChargeFrac      eWeaponVar.ammo_per_shot
+            chargeFrac          player_chargeFrac
+		}
+	}
+
+    //1x-2x
+	UiData9
+	{
+		"ui"						"ui/holo_variable_sights"
+		"mesh"						"models/weapons/attachments/holo_variable_sights"
+		Args
+		{
+			vis						player_zoomfrac
+			ammo					weapon_ammoClipCount
+			clipSize				eWeaponVar.ammo_per_shot
+			zoomFOV                 weapon_zoom_fov
+			centerOffset			weapon_ads_center_offset
+			showChargeFrac          eWeaponVar.ammo_per_shot
+			chargeFrac              player_chargeFrac
+		}
+	}
+
+    //3x
+	UiData16
+	{
+		"ui"					"ui/hcog_ranged_sights"
+		"mesh"					"models/weapons/attachments/acgs_rui_upper"
+		Args
+		{
+			vis					player_zoomfrac
+			ammo				weapon_ammoClipCount
+			clipSize			eWeaponVar.ammo_per_shot
+            zoomFOV             weapon_zoom_fov
+			centerOffset		weapon_ads_center_offset
+			showChargeFrac      eWeaponVar.ammo_per_shot
+			chargeFrac          player_chargeFrac
+		}
+	}
+
+    //2x-4x
+	UiData17
+	{
+		"ui"	"ui/aog_variable_sights"
+		"mesh" "models/weapons/attachments/aog_variable_sights"
+		Args
+		{
+			vis					player_zoomfrac
+			ammo				weapon_ammoClipCount
+			clipSize			eWeaponVar.ammo_per_shot
+            zoomFOV             weapon_zoom_fov
+			centerOffset		weapon_ads_center_offset
+		}
 	}
 
 	"ui1_enable"		"1"
@@ -576,7 +819,20 @@ WeaponData
 		"mesh"							"models/weapons/attachments/lstar_rui_lower"
 		Args
 		{
-			clipAmmo			weapon_ammo
+			vis					player_zoomfrac
+			centerOffset		weapon_ads_center_offset
+		}
+	}
+
+	"ui2_enable"		"1"
+	"ui2_draw_cloaked"	"1"
+	UiData2
+	{
+		"ui"					"ui/lstar_screens"
+		"mesh"					"models/weapons/attachments/lstar_rui_lower"
+		Args
+		{
+			clipAmmo			weapon_ammoClipCount
 			clipSize			weapon_clipSize
 			lifetimeShots		weapon_lifetime_shots
 			ammoFrac			weapon_ammofrac
@@ -591,28 +847,14 @@ WeaponData
 		}
 	}
 
-	"ui2_enable"		"0"
-	"ui2_draw_cloaked"	"1"
-	UiData2
-	{
-		"ui"					"ui/aog_ammo_counter_lstar"
-		"mesh"					"models/weapons/attachments/aog_rui_lower"
-		Args
-		{
-			vis					player_zoomfrac
-			ammo				weapon_ammo
-			clipSize			weapon_clipSize
-		}
-	}
-
 	"ui3_enable"		"0"
 	UiData3
 	{
-		"ui"						"ui/lstar_screens_rcee"
-		"mesh"						"models/weapons/attachments/lstar_rui_lower"
+		"ui"					"ui/lstar_screens_rcee"
+		"mesh"					"models/weapons/attachments/lstar_rui_lower"
 		Args
 		{
-			lastDryFireTime			weapon_latest_dryfire_time
+			lastDryFireTime		weapon_latest_dryfire_time
 		}
 	}
 
@@ -624,14 +866,14 @@ WeaponData
     "ui10_draw_cloaked"	"1"
     UiData10
     {
-        "ui"							"ui/cro_threat_sights"
-        "mesh"							"models/weapons/attachments/cro_rui_upper"
+        "ui"					"ui/cro_threat_sights"
+        "mesh"					"models/weapons/attachments/cro_rui_upper"
         Args
         {
-            zoomFrac					player_zoomfrac
-            ammo						weapon_ammo
-            clipSize					weapon_clipSize
-            centerOffset				weapon_ads_center_offset
+            zoomFrac			player_zoomfrac
+            ammo				weapon_ammoClipCount
+            clipSize			weapon_clipSize
+            centerOffset		weapon_ads_center_offset
         }
     }
 

--- a/weapons/mp_weapon_r97.txt
+++ b/weapons/mp_weapon_r97.txt
@@ -11,7 +11,6 @@ WeaponData
 	"longdesc"										"#WPN_R97_LONGDESC"
 
 	"weapon_type_flags"								"WPT_PRIMARY"
-	"ammo_pool_type"								"bullet"
 
 	"menu_icon"										"rui/weapon_icons/r5/weapon_r97"
 	"hud_icon"										"rui/weapon_icons/r5/weapon_r97"
@@ -42,8 +41,8 @@ WeaponData
 	"chroma_color"									"1 .9 .5"
 
 	//Sounds
-	"fire_sound_1_player_1p"						"Weapon_bulletCasings.Bounce"
-	"fire_sound_1_player_3p"						"Weapon_bulletCasings.Bounce"
+	//"fire_sound_1_player_1p"						"Weapon_bulletCasings.Bounce"
+	//"fire_sound_1_player_3p"						"Weapon_bulletCasings.Bounce"
 	"fire_sound_2_player_1p"						"Weapon_R97_SecondShot_1P"
 	"fire_sound_2_player_3p"						""
 	"fire_sound_2_npc"								"Weapon_r97_secondshot_npc"
@@ -71,24 +70,37 @@ WeaponData
 	"damage_type" 									"bullet"
 
 	// Ammo
-		"ammo_clip_size"   								"19"
+	"ammo_clip_size"   								"19"
 
-		"ammo_default_total"							"150"
-		"ammo_stockpile_max"							"150"
-		"ammo_no_remove_from_stockpile"					"1"
-		"ammo_min_to_fire"								"1"
+    "ammo_stockpile_max"					        "36"
+    "ammo_default_total"					        "0"
+    "ammo_no_remove_from_stockpile"			        "1"
+    "uses_ammo_pool"						        "1"
+    "ammo_pool_type"								"bullet"
+      
+    "ammo_min_to_fire"								"1"
+    "low_ammo_fraction" 					        "0.3"
 
-		// Damage - When Used by Players
+    // Damage - When Used by Players
+                      
     "damage_near_value"   							"12"
     "damage_far_value"								"12"
     "damage_very_far_value"							"12"
     "damage_near_value_titanarmor"					"12"
     "damage_far_value_titanarmor" 					"12"
     "damage_very_far_value_titanarmor" 				"12"
+     
+                                     
+                                  
+                                      
+                                           
+                                           
+                                               
       
     "damage_rodeo" 									"110"
 
-	   // Damage - When Used by NPCs
+
+    // Damage - When Used by NPCs
     "npc_damage_near_value_titanarmor"				"0"
     "npc_damage_far_value_titanarmor" 				"0"
     "npc_damage_near_value"   						"9"
@@ -106,7 +118,7 @@ WeaponData
 	"npc_max_engage_range"							"1100"
 	"npc_min_engage_range_heavy_armor"				"500"
 	"npc_max_engage_range_heavy_armor"				"2000"
-	
+
 	"fx_muzzle_flash_view"							""
 	"fx_muzzle_flash_world"							""
 	"fx_muzzle_flash_attach"						""
@@ -203,17 +215,27 @@ WeaponData
     "clip_bodygroup_show_for_milestone_2"	"1"
     "clip_bodygroup_show_for_milestone_3"	"1"
 
-	Mods
-	{
+    	Mods
+    	{
 		survival_finite_ammo
         {
             "ammo_default_total"					"0"
             "ammo_stockpile_max"					"36"
             "ammo_no_remove_from_stockpile"			"0"
 
-            "low_ammo_fraction" 					"0.3"
 
-	   		"uses_ammo_pool"						"1"
+           "reload_time"						"*0.75"
+           "reload_time_late1"					"*0.75"
+           "reload_time_late2"					"*0.75"
+           "reload_time_late3"					"*0.75"
+           "reload_time_late4"					"*0.75"
+           "reload_time_late5"					"*0.75"
+           "reloadempty_time"					"*0.75"
+           "reloadempty_time_late1"			"*0.75"
+           "reloadempty_time_late2"			"*0.75"
+           "reloadempty_time_late3"			"*0.75"
+           "reloadempty_time_late4"			"*0.75"
+           "reloadempty_time_late5"			"*0.75"
         }
 
         optic_cq_hcog_classic
@@ -245,7 +267,7 @@ WeaponData
 			"bodygroup2_set" 						"0"
 			"ui2_enable" 							"0"
 		}
-
+			
 		barrel_stabilizer_l4_flash_hider
         {
 			"fx_muzzle_flash_view"							""
@@ -271,7 +293,7 @@ WeaponData
 			"viewmodel"   									"mdl/weapons/r97/ptpov_r97_legendary_01.rmdl"
 			"playermodel" 									"mdl/weapons/r97/w_r97_legendary_01.rmdl"
 		}
-
+		
 	}
 
 
@@ -302,7 +324,7 @@ WeaponData
 			clipCount					weapon_ammoClipCount
 		}
 	}
-
+	
 	active_crosshair_count				"1"
 	rui_crosshair_index					"0"
 


### PR DESCRIPTION
**Triple Take**
- Projectile size increased
- Improved hipfire spread
- Tightened bullet pattern when fully choked
- Ammo per shot reduced to 1 (was 3)
- Magazines sizes adjusted to match the new ammo costs
- Purple Mag: Increased to 10 shots (was 9)

**R-99 SMG**
- Removed 1 bullet from base and all magazines
- No Magazine reduced to 19 (was 20)
- White Magazine reduced to 21 (was 22)
- Blue Magazine reduced to 24 (was 25)
- Purple magazine reduced to 27 (was 28)

**Charge Rifle**
- Reduced shots per magazine to 3 (was 4)

**L-Star EMG**
- Added Disruptor Rounds: 60% damage increase against shields
- Base Damage Reduced to 16 (was 17)
- Improved recoil pattern
- Removed barrel
- Ammo Stockpile: 324
