### PR TITLE
Update _gamemode_1v1.nut

### DIFF
--- a/vscripts/gamemodes/fs_1v1/_gamemode_1v1.nut
+++ b/vscripts/gamemodes/fs_1v1/_gamemode_1v1.nut
@@ -1199,6 +1199,10 @@ void function soloModeThread(LocPair waitingRoomLocation)
 		{
 			if(!IsValid(restingPlayer)) continue
 			TakeAmmoFromPlayer(restingPlayer)   //子弹设为0
+			entity checkhand = restingPlayer.GetOffhandWeapon( OFFHAND_MELEE )
+			if ( checkhand != null ){
+			restingPlayer.TakeOffhandWeapon( OFFHAND_MELEE ) //quick patch mkos
+			}
 			if(!IsAlive(restingPlayer)  )
 			{
 				thread respawnInSoloMode(restingPlayer)


### PR DESCRIPTION
If a player rests, and then spectates, and jumps (to leave rest) they are able to melee other players while in rest mode.

Quick patch to remove offhand when joining back to rest mode.

Probably can be implemented better instead of during loop.