### PR TITLE
Update sh_character_cosmetics.nut

### DIFF
--- a/vscripts/_utility.gnut
+++ b/vscripts/_utility.gnut
@@ -3604,6 +3604,9 @@ void function DeployViewModelAndEnableWeapons( entity player )
 //Investigate: This might be getting called without enableoffhandweapons being called. If so,  Server_TurnOffhandWeaponsDisabledOn() should be used instead of this stack system.
 void function DisableOffhandWeapons( entity player )
 {
+	if(player.IsPlayer()) 
+		return 
+		
 	player.Server_TurnOffhandWeaponsDisabledOn()
 	player.p.disableOffhandWeaponsStackCount++
 }

--- a/vscripts/_utility.gnut
+++ b/vscripts/_utility.gnut
@@ -3604,7 +3604,7 @@ void function DeployViewModelAndEnableWeapons( entity player )
 //Investigate: This might be getting called without enableoffhandweapons being called. If so,  Server_TurnOffhandWeaponsDisabledOn() should be used instead of this stack system.
 void function DisableOffhandWeapons( entity player )
 {
-	if(player.IsPlayer()) 
+	if(!player.IsPlayer()) 
 		return 
 		
 	player.Server_TurnOffhandWeaponsDisabledOn()

--- a/vscripts/sh_character_cosmetics.nut
+++ b/vscripts/sh_character_cosmetics.nut
@@ -403,7 +403,10 @@ void function CharacterSkin_Apply( entity ent, ItemFlavor skin )
 	asset bodyModel = CharacterSkin_GetBodyModel( skin )
 	asset armsModel = CharacterSkin_GetArmsModel( skin )
 
+	int savedCamo = ent.GetCamo()
+	
 	ent.SetSkin( 0 ) // Lame that we need this, but this avoids invalid skin errors when the model changes and the currently shown skin index doesn't exist for the new model
+	
 	ent.SetModel( bodyModel )
 
 	int skinIndex = ent.GetSkinIndexByName( CharacterSkin_GetSkinName( skin ) )
@@ -412,11 +415,18 @@ void function CharacterSkin_Apply( entity ent, ItemFlavor skin )
 	if ( skinIndex == -1 )
 	{
 		skinIndex = 0
-		camoIndex = 0
+		camoIndex = savedCamo
 	}
-
-	ent.SetSkin( skinIndex )
-	ent.SetCamo( camoIndex )
+	
+	try 
+	{
+		ent.SetSkin( skinIndex )
+		ent.SetCamo( camoIndex )
+	} 
+	catch(skinerror)
+	{
+		//sqerror("(catch: skinerror) SKIN ERROR: " + skinerror)
+	}
 
 	#if SERVER
 		if ( ent.IsPlayer() )


### PR DESCRIPTION
Setting the camo to 0 generates an invalid range. 

Therefore, when the skin is invalid, the fallback should not be an index of 0, but the index of the current camo instead.